### PR TITLE
Build for multiple CPU architectures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,11 @@ jobs:
         with:
           cosign-release: 'v1.9.0'
 
-
+      # Setup QEMU
+      # https://github.com/marketplace/actions/docker-setup-buildx#with-qemu
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2.0.0
+      
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
@@ -78,6 +82,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # https://github.com/docker/setup-qemu-action#about
+          # platforms: linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
I added amd64, arm64, armv6, armv7, and commented the list of supported architectures.

By the way, you should setup Dependabot in order to update (via pull requests) the Actions you use (e.g. docker/setup-qemu-action): https://github.com/marketplace/actions/docker-setup-buildx#keep-up-to-date-with-github-dependabot