### PR TITLE
Support Gotify

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -89,5 +89,10 @@
         "allow": "Zum Zulassen anklicken",
         "updating": "Aktualisieren",
         "wait": "Bitte warten"
+    },
+    "gotify": {
+        "apps": "Anwendungen",
+        "clients": "Kunden",
+        "messages": "Mitteilungen"
     }
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -101,5 +101,11 @@
         "apps": "Anwendungen",
         "clients": "Kunden",
         "messages": "Mitteilungen"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -112,5 +112,11 @@
         "apps": "Applications",
         "clients": "Clients",
         "messages": "Messages"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -100,5 +100,10 @@
         "enabled": "Enabled",
         "disabled": "Disabled",
         "total": "Total"
+    },
+    "gotify": {
+        "apps": "Applications",
+        "clients": "Clients",
+        "messages": "Messages"
     }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -89,5 +89,10 @@
         "allow": "Click to allow",
         "updating": "Updating",
         "wait": "Please wait"
+    },
+    "gotify": {
+        "apps": "Aplicaciones",
+        "clients": "Clientela",
+        "messages": "Mensajes"
     }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -101,5 +101,11 @@
         "apps": "Aplicaciones",
         "clients": "Clientela",
         "messages": "Mensajes"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -112,5 +112,11 @@
         "apps": "Applications",
         "clients": "Clients",
         "messages": "Messages"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -100,5 +100,10 @@
         "allow": "Click to allow",
         "updating": "Updating",
         "wait": "Please wait"
+    },
+    "gotify": {
+        "apps": "Applications",
+        "clients": "Clients",
+        "messages": "Messages"
     }
 }

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -89,5 +89,10 @@
         "allow": "Click to allow",
         "updating": "Updating",
         "wait": "Please wait"
+    },
+    "gotify": {
+        "apps": "Applications",
+        "clients": "Clients",
+        "messages": "Messages"
     }
 }

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -101,5 +101,11 @@
         "apps": "Applications",
         "clients": "Clients",
         "messages": "Messages"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -89,5 +89,10 @@
         "updating": "Oppdaterer …",
         "wait": "Vent litt …",
         "current": "Nåværende posisjon"
+    },
+    "gotify": {
+        "apps": "Applications",
+        "clients": "Clients",
+        "messages": "Messages"
     }
 }

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -101,5 +101,11 @@
         "apps": "Applications",
         "clients": "Clients",
         "messages": "Messages"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -89,5 +89,10 @@
         "enabled": "Enabled",
         "disabled": "Disabled",
         "total": "Total"
+    },
+    "gotify": {
+        "apps": "Applications",
+        "clients": "Clients",
+        "messages": "Messages"
     }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -101,5 +101,11 @@
         "apps": "Applications",
         "clients": "Clients",
         "messages": "Messages"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -100,5 +100,10 @@
         "allow": "Clicar para permitir",
         "updating": "A atualizar",
         "wait": "Por favor aguarde"
+    },
+    "gotify": {
+        "apps": "Aplicações",
+        "clients": "Clientes",
+        "messages": "Mensagens"
     }
 }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -112,5 +112,11 @@
         "apps": "Aplicações",
         "clients": "Clientes",
         "messages": "Mensagens"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -89,5 +89,10 @@
         "current": "Current Location",
         "allow": "Click to allow",
         "updating": "Updating"
+    },
+    "gotify": {
+        "apps": "Aplicações",
+        "clients": "Clientes",
+        "messages": "Mensagens"
     }
 }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -101,5 +101,11 @@
         "apps": "Aplicações",
         "clients": "Clientes",
         "messages": "Mensagens"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -89,5 +89,10 @@
         "allow": "Click to allow",
         "updating": "Updating",
         "wait": "Please wait"
+    },
+    "gotify": {
+        "apps": "Aplicações",
+        "clients": "Clientes",
+        "messages": "Mensagens"
     }
 }

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -101,5 +101,11 @@
         "apps": "Aplicações",
         "clients": "Clientes",
         "messages": "Mensagens"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -89,5 +89,10 @@
         "allow": "Click to allow",
         "updating": "Updating",
         "wait": "Please wait"
+    },
+    "gotify": {
+        "apps": "Aplicações",
+        "clients": "Clientes",
+        "messages": "Mensagens"
     }
 }

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -101,5 +101,11 @@
         "apps": "Aplicações",
         "clients": "Clientes",
         "messages": "Mensagens"
+    },
+    "sabnzbd": {
+        "status": "Status",
+        "speed": "Speed",
+        "remaining": "Remaining",
+        "timeleft": "Time left"
     }
 }

--- a/src/components/services/widget.jsx
+++ b/src/components/services/widget.jsx
@@ -15,6 +15,7 @@ import Traefik from "./widgets/service/traefik";
 import Jellyseerr from "./widgets/service/jellyseerr";
 import Npm from "./widgets/service/npm";
 import Tautulli from "./widgets/service/tautulli";
+import Gotify from "./widgets/service/gotify";
 
 const widgetMappings = {
   docker: Docker,
@@ -32,6 +33,7 @@ const widgetMappings = {
   jellyseerr: Jellyseerr,
   npm: Npm,
   tautulli: Tautulli,
+  gotify: Gotify,
 };
 
 export default function Widget({ service }) {

--- a/src/components/services/widget.jsx
+++ b/src/components/services/widget.jsx
@@ -17,6 +17,7 @@ import Overseerr from "./widgets/service/overseerr";
 import Npm from "./widgets/service/npm";
 import Tautulli from "./widgets/service/tautulli";
 import Gotify from "./widgets/service/gotify";
+import Sabnzbd from "./widgets/service/sabnzbd";
 
 const widgetMappings = {
   docker: Docker,
@@ -36,6 +37,7 @@ const widgetMappings = {
   npm: Npm,
   tautulli: Tautulli,
   gotify: Gotify,
+  sabnzbd: Sabnzbd
 };
 
 export default function Widget({ service }) {

--- a/src/components/services/widgets/service/gotify.jsx
+++ b/src/components/services/widgets/service/gotify.jsx
@@ -1,0 +1,29 @@
+import useSWR from "swr";
+import { useTranslation } from "react-i18next";
+
+import Widget from "../widget";
+import Block from "../block";
+
+import { formatApiUrl } from "utils/api-helpers";
+
+export default function Gotify({ service }) {
+  const { t } = useTranslation();
+
+  const config = service.widget;
+
+  const { data: appsData, error: appsError } = useSWR(formatApiUrl(config, `application`));
+  const { data: messagesData, error: messagesError } = useSWR(formatApiUrl(config, `message`));
+  const { data: clientsData, error: clientsError } = useSWR(formatApiUrl(config, `client`));
+
+  if (appsError || messagesError || clientsError) {
+    return <Widget error={t("widget.api_error")} />;
+  }
+
+  return (
+    <Widget>
+      <Block label={t("gotify.apps")} value={appsData?.length} />
+      <Block label={t("gotify.clients")} value={clientsData?.length} />
+      <Block label={t("gotify.messages")} value={messagesData?.messages?.length} />
+    </Widget>
+  );
+}

--- a/src/components/services/widgets/service/sabnzbd.jsx
+++ b/src/components/services/widgets/service/sabnzbd.jsx
@@ -1,0 +1,41 @@
+import useSWR from "swr";
+import { useTranslation } from "react-i18next";
+
+import Widget from "../widget";
+import Block from "../block";
+
+import { formatApiUrl } from "utils/api-helpers";
+
+export default function Sabnzbd({ service }) {
+  const { t } = useTranslation("common");
+
+  const config = service.widget;
+  const { data: statusData, error: statusError } = useSWR(formatApiUrl(config, "mode=queue"));
+
+  if (statusError) {
+    return <Widget error={t("widget.api_error")} />;
+  }
+
+  if (!statusData) {
+    return (
+      <Widget>
+        <Block label={t("sabnzbd.status")} />
+        <Block label={t("sabnzbd.speed")} />
+        <Block label={t("sabnzbd.remaining")} />
+        <Block label={t("sabnzbd.timeleft")} />
+      </Widget>
+    );
+  }
+
+  return (
+    <Widget>
+      <Block label={t("sabnzbd.status")} value={statusData?.queue?.status } />
+      <Block label={t("sabnzbd.speed")} value={statusData?.queue?.speed } />
+      <Block
+        label={t("sabnzbd.remaining")}
+        value={t("common.bytes", { value: statusData?.queue?.mbleft * 1024 * 1024 })}
+      />
+      <Block label={t("sabnzbd.timeleft")} value={statusData?.queue?.timeleft} />
+    </Widget>
+  );
+}

--- a/src/pages/api/services/proxy.js
+++ b/src/pages/api/services/proxy.js
@@ -14,6 +14,7 @@ const serviceProxyHandlers = {
   speedtest: genericProxyHandler,
   tautulli: genericProxyHandler,
   traefik: genericProxyHandler,
+  sabnzbd: genericProxyHandler,
   // uses X-API-Key header auth
   gotify: credentialedProxyHandler,
   portainer: credentialedProxyHandler,

--- a/src/pages/api/services/proxy.js
+++ b/src/pages/api/services/proxy.js
@@ -15,6 +15,7 @@ const serviceProxyHandlers = {
   tautulli: genericProxyHandler,
   traefik: genericProxyHandler,
   // uses X-API-Key header auth
+  gotify: credentialedProxyHandler,
   portainer: credentialedProxyHandler,
   jellyseerr: credentialedProxyHandler,
   ombi: credentialedProxyHandler,

--- a/src/utils/api-helpers.js
+++ b/src/utils/api-helpers.js
@@ -14,6 +14,7 @@ const formats = {
   ombi: `{url}/api/v1/{endpoint}`,
   npm: `{url}/api/{endpoint}`,
   gotify: `{url}/{endpoint}`,
+  sabnzbd: `{url}/api?output=json&apikey={key}&{endpoint}`,
 };
 
 export function formatApiCall(api, args) {

--- a/src/utils/api-helpers.js
+++ b/src/utils/api-helpers.js
@@ -12,6 +12,7 @@ const formats = {
   jellyseerr: `{url}/api/v1/{endpoint}`,
   ombi: `{url}/api/v1/{endpoint}`,
   npm: `{url}/api/{endpoint}`,
+  gotify: `{url}/{endpoint}`,
 };
 
 export function formatApiCall(api, args) {

--- a/src/utils/proxies/credentialed.js
+++ b/src/utils/proxies/credentialed.js
@@ -8,15 +8,19 @@ export default async function credentialedProxyHandler(req, res) {
   if (group && service) {
     const widget = await getServiceWidget(group, service);
 
+    var headersData
+    if(widget.type == "gotify"){
+      headersData = {"X-gotify-Key": `${widget.key}`,"Content-Type": "application/json",}
+    }else{
+      headersData = {"X-API-Key": `${widget.key}`,"Content-Type": "application/json",}
+    }
+
     if (widget) {
       const url = new URL(formatApiCall(widget.type, { endpoint, ...widget }));
       const [status, contentType, data] = await httpProxy(url, {
         withCredentials: true,
         credentials: "include",
-        headers: {
-          "X-API-Key": `${widget.key}`,
-          "Content-Type": "application/json",
-        },
+        headers: headersData,
       });
 
       if (contentType) res.setHeader("Content-Type", contentType);

--- a/src/utils/proxies/credentialed.js
+++ b/src/utils/proxies/credentialed.js
@@ -3,13 +3,13 @@ import { formatApiCall } from "utils/api-helpers";
 import { httpProxy } from "utils/http";
 
 export default async function credentialedProxyHandler(req, res) {
+  let headersData
   const { group, service, endpoint } = req.query;
 
   if (group && service) {
     const widget = await getServiceWidget(group, service);
 
-    var headersData
-    if(widget.type == "gotify"){
+    if(widget.type === "gotify"){
       headersData = {"X-gotify-Key": `${widget.key}`,"Content-Type": "application/json",}
     }else{
       headersData = {"X-API-Key": `${widget.key}`,"Content-Type": "application/json",}


### PR DESCRIPTION
Hi,

First of all, congratulations for the project.
I added this simple support for the self hosted notification service, Gotify (https://gotify.net/docs/pushmsg).

Requirements: 

1. Create a Client on Gotify web page
![image](https://user-images.githubusercontent.com/1280521/189511531-46d45eac-9183-42a7-9986-aa83360cb59a.png)

2. Add the service
```- Group Service:
    - One Service:
        href: http://gotify.host.or.ip
        icon: gotify.png
        description: Gotify
        widget:
            type: gotify
            url: http://gotify.host.or.ip
            key: clienttoken
```
3. Generated visual lists the configured applications, clients and messages unread
![image](https://user-images.githubusercontent.com/1280521/189511621-7d92ae4d-45ee-43e0-a23f-b22638181cf1.png)

Note:  The file `src/utils/proxies/credentialed.js` should be reviewed because Gotify requires an header named `X-gotify-Key` and it should be handled dynamically not with a specific condition.

Thanks

