### PR TITLE
Add option to select a default language

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,17 +1,26 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { SWRConfig } from "swr";
+import useSWR, { SWRConfig } from "swr";
 
 import "styles/globals.css";
 import "styles/weather-icons.css";
 import "styles/theme.css";
 
-import "utils/i18n";
+import i18n from "utils/i18n";
+
+const swr = (resource, init) => fetch(resource, init).then((res) => res.json());
 
 function MyApp({ Component, pageProps }) {
+  const { data } = useSWR(`/api/settings`, swr);
+  console.log(data);
+  if (data?.language) {
+    console.log("custom language");
+    i18n.changeLanguage(data.language);
+  }
+
   return (
     <SWRConfig
       value={{
-        fetcher: (resource, init) => fetch(resource, init).then((res) => res.json()),
+        fetcher: swr,
       }}
     >
       <Component {...pageProps} />

--- a/src/pages/api/settings.js
+++ b/src/pages/api/settings.js
@@ -1,0 +1,7 @@
+import { getSettings } from "utils/config";
+
+export default async function handler(req, res) {
+  const settings = await getSettings();
+
+  return res.send(settings);
+}


### PR DESCRIPTION
```
# For configuration options and examples, please see:
# https://github.com/benphelps/homepage/wiki/Settings

providers:
  openweathermap: openweathermapapikey
  weatherapi: weatherapiapikey

language: de # optional

```

Adds the ability to select a default language https://github.com/benphelps/homepage/issues/157