### PR TITLE
Add backgroundOpacity option

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -46,6 +46,7 @@ export default function Home({ settings }) {
   if (settings.background) {
     wrappedStyle.backgroundImage = `url(${settings.background})`;
     wrappedStyle.backgroundSize = "cover";
+    wrappedStyle.opacity = settings.backgroundOpacity ?? 1;
   }
 
   useEffect(() => {


### PR DESCRIPTION
This fix improves readability with bright background images adding a tint.

Just add a new line to the `settings.yaml` (defaults to 1):
```yaml
backgroundOpacity: 0.5
```