### PR TITLE
Proposal to add ability to map data in a proxy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/next",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/src/utils/proxies/generic.js
+++ b/src/utils/proxies/generic.js
@@ -2,7 +2,7 @@ import getServiceWidget from "utils/service-helpers";
 import { formatApiCall } from "utils/api-helpers";
 import { httpProxy } from "utils/http";
 
-export default async function genericProxyHandler(req, res) {
+export default async function genericProxyHandler(req, res, mapper) {
   const { group, service, endpoint } = req.query;
 
   if (group && service) {
@@ -23,13 +23,18 @@ export default async function genericProxyHandler(req, res) {
         headers,
       });
 
+      let resultData = data;
+      if (mapper) {
+        resultData = mapper(endpoint, data);
+      }
+
       if (contentType) res.setHeader("Content-Type", contentType);
 
       if (status === 204 || status === 304) {
         return res.status(status).end();
       }
 
-      return res.status(status).send(data);
+      return res.status(status).send(resultData);
     }
   }
 


### PR DESCRIPTION
This is a proof of concept on how to reduce the amount of data returned to the client via the existing proxy system, at the cost of additional CPU and memory utilization.  An upshot is that this could allow for clients to request data that you might not want to expose to those clients and potentially mask or remove any sensitive data.