### PR TITLE
Add global refresh interval for all SWR calls

### DIFF
--- a/src/components/widgets/openweathermap/weather.jsx
+++ b/src/components/widgets/openweathermap/weather.jsx
@@ -11,8 +11,9 @@ function Widget({ options }) {
   const { t, i18n } = useTranslation();
 
   const { data, error } = useSWR(
-    `/api/widgets/openweathermap?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`
-  );
+    `/api/widgets/openweathermap?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`, {
+      refreshInterval: null
+    });
 
   if (error || data?.cod === 401 || data?.error) {
     return (

--- a/src/components/widgets/resources/cpu.jsx
+++ b/src/components/widgets/resources/cpu.jsx
@@ -8,9 +8,7 @@ import UsageBar from "./usage-bar";
 export default function Cpu({ expanded }) {
   const { t } = useTranslation();
 
-  const { data, error } = useSWR(`/api/widgets/resources?type=cpu`, {
-    refreshInterval: 1500,
-  });
+  const { data, error } = useSWR(`/api/widgets/resources?type=cpu`);
 
   if (error || data?.error) {
     return (

--- a/src/components/widgets/resources/disk.jsx
+++ b/src/components/widgets/resources/disk.jsx
@@ -8,9 +8,7 @@ import UsageBar from "./usage-bar";
 export default function Disk({ options, expanded }) {
   const { t } = useTranslation();
 
-  const { data, error } = useSWR(`/api/widgets/resources?type=disk&target=${options.disk}`, {
-    refreshInterval: 1500,
-  });
+  const { data, error } = useSWR(`/api/widgets/resources?type=disk&target=${options.disk}`);
 
   if (error || data?.error) {
     return (

--- a/src/components/widgets/resources/memory.jsx
+++ b/src/components/widgets/resources/memory.jsx
@@ -8,9 +8,7 @@ import UsageBar from "./usage-bar";
 export default function Memory({ expanded }) {
   const { t } = useTranslation();
 
-  const { data, error } = useSWR(`/api/widgets/resources?type=memory`, {
-    refreshInterval: 1500,
-  });
+  const { data, error } = useSWR(`/api/widgets/resources?type=memory`);
 
   if (error || data?.error) {
     return (

--- a/src/components/widgets/weather/weather.jsx
+++ b/src/components/widgets/weather/weather.jsx
@@ -11,8 +11,9 @@ function Widget({ options }) {
   const { t, i18n } = useTranslation();
 
   const { data, error } = useSWR(
-    `/api/widgets/weather?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`
-  );
+    `/api/widgets/weather?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`, {
+      refreshInterval: null
+    });
 
   if (error || data?.error) {
     return (

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -14,6 +14,7 @@ function MyApp({ Component, pageProps }) {
   return (
     <SWRConfig
       value={{
+        refreshInterval: 1500,
         fetcher: (resource, init) => fetch(resource, init).then((res) => res.json()),
       }}
     >


### PR DESCRIPTION
Added global refresh interval for all widgets using SWR.

This allow to all widgets to auto refresh data each 1,5 seconds like in resource widgets except for weather widgets that not need refreshing data.