### PR TITLE
Fix Prowlarr show API Error

### DIFF
--- a/src/widgets/prowlarr/widget.js
+++ b/src/widgets/prowlarr/widget.js
@@ -1,7 +1,7 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  api: "{url}/api/v1/{endpoint}",
+  api: "{url}/api/v1/{endpoint}?apikey={key}",
   proxyHandler: genericProxyHandler,
 
   mappings: {


### PR DESCRIPTION
During the refactor we left the `?apikey={key}` part off of the api widget property.