### PR TITLE
Fix resources CPU label...

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -25,6 +25,7 @@
         "placeholder": "Search…"
     },
     "resources": {
+        "cpu": "CPU",
         "total": "Total",
         "free": "Free",
         "used": "Used",

--- a/src/components/widgets/resources/cpu.jsx
+++ b/src/components/widgets/resources/cpu.jsx
@@ -30,7 +30,7 @@ export default function Cpu({ expanded }) {
         <div className="flex flex-col ml-3 text-left min-w-[85px]">
           <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
             <div className="pl-0.5">-</div>
-            <div className="pr-1">{t("docker.cpu")}</div>
+            <div className="pr-1">{t("resources.cpu")}</div>
           </div>
           {expanded && (
             <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
@@ -59,7 +59,7 @@ export default function Cpu({ expanded }) {
               maximumFractionDigits: 0,
             })}
           </div>
-          <div className="pr-1">{t("docker.cpu")}</div>
+          <div className="pr-1">{t("resources.cpu")}</div>
         </div>
         {expanded && (
           <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">


### PR DESCRIPTION
The target is not to use the same label for CPU in docker widgets and in resources information, due to "problems" with translations (https://github.com/benphelps/homepage/discussions/312)...