### PR TITLE
Feature: support sort layout

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -177,7 +177,6 @@ function Home({ initialSettings }) {
   
   const servicesAndBookmarks = [...services.map(sg => sg.services).flat(), ...bookmarks.map(bg => bg.bookmarks).flat()]
 
-
   useEffect(() => {
     if (settings.language) {
       i18n.changeLanguage(settings.language);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -177,20 +177,6 @@ function Home({ initialSettings }) {
   
   const servicesAndBookmarks = [...services.map(sg => sg.services).flat(), ...bookmarks.map(bg => bg.bookmarks).flat()]
 
-  // sort layout
-  const layouts = Object.keys(initialSettings.layout);
-  let sortedServices = [];
-  const copiedServices = services.slice();
-  layouts.forEach((currentServer) => {
-    if (initialSettings.layout[currentServer]?.sort) {
-      const idx = copiedServices.findIndex((service) => service.name === currentServer);
-      sortedServices.push(...copiedServices.splice(idx, 1));
-    }
-  });
-
-  if (copiedServices.length) {
-    sortedServices = sortedServices.concat(copiedServices);
-  }
 
   useEffect(() => {
     if (settings.language) {
@@ -278,9 +264,9 @@ function Home({ initialSettings }) {
           )}
         </div>
 
-        {sortedServices && (
+        {services && (
           <div className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
-            {sortedServices.map((group) => (
+            {services.map((group) => (
               <ServicesGroup key={group.name} services={group} layout={initialSettings.layout?.[group.name]} />
             ))}
           </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -177,6 +177,21 @@ function Home({ initialSettings }) {
   
   const servicesAndBookmarks = [...services.map(sg => sg.services).flat(), ...bookmarks.map(bg => bg.bookmarks).flat()]
 
+  // sort layout
+  const layouts = Object.keys(initialSettings.layout);
+  let sortedServices = [];
+  const copiedServices = services.slice();
+  layouts.forEach((currentServer) => {
+    if (initialSettings.layout[currentServer]?.sort) {
+      const idx = copiedServices.findIndex((service) => service.name === currentServer);
+      sortedServices.push(...copiedServices.splice(idx, 1));
+    }
+  });
+
+  if (copiedServices.length) {
+    sortedServices = sortedServices.concat(copiedServices);
+  }
+
   useEffect(() => {
     if (settings.language) {
       i18n.changeLanguage(settings.language);
@@ -263,9 +278,9 @@ function Home({ initialSettings }) {
           )}
         </div>
 
-        {services && (
+        {sortedServices && (
           <div className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
-            {services.map((group) => (
+            {sortedServices.map((group) => (
               <ServicesGroup key={group.name} services={group} layout={initialSettings.layout?.[group.name]} />
             ))}
           </div>

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -77,6 +77,7 @@ export async function servicesResponse() {
   ];
 
   const mergedGroups = [];
+  const definedLayouts = initialSettings.layout ? Object.keys(initialSettings.layout) : null;
 
   mergedGroupsNames.forEach((groupName) => {
     const discoveredGroup = discoveredServices.find((group) => group.name === groupName) || { services: [] };
@@ -87,21 +88,14 @@ export async function servicesResponse() {
       services: [...discoveredGroup.services, ...configuredGroup.services].filter((service) => service),
     };
 
-    mergedGroups.push(mergedGroup);
-  });
-
-  let sortedServices = [];
-
-  const layouts = Object.keys(initialSettings.layout);
-  layouts.forEach((currentServer) => {
-    if (initialSettings.layout[currentServer]?.sort) {
-      const idx = mergedGroups.findIndex((service) => service.name === currentServer);
-      sortedServices.push(...mergedGroups.splice(idx, 1));
+    if (definedLayouts) {
+      const layoutIndex = definedLayouts.findIndex(layout => layout === mergedGroup.name);
+      if (layoutIndex > -1) mergedGroups.splice(layoutIndex, 0, mergedGroup);
+      else mergedGroups.push(mergedGroup);
+    } else {
+      mergedGroups.push(mergedGroup);
     }
   });
-  if (mergedGroups.length) {
-    sortedServices = sortedServices.concat(mergedGroups);
-  }
 
-  return sortedServices;
+  return mergedGroups;
 }


### PR DESCRIPTION
This PR supports sorting of layouts so that the user can place the specified layout at the top

By default, the behavior remains the same as before, and the layout to be sorted needs to be declared manually for it to take effect

Edit:
settings.yaml
```
layout:
  layout1:
    sort: true  # enable
    style: row
    columns: 3
  layout2:
    sort: true
    style: row
    columns: 3
  layout3:
    style: row
    columns: 3
  layout4:
    style: row
    columns: 3
```