### PR TITLE
Decompose i18n labels for Unifi widget

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "**/.next": true,
+        "**/node_modules": true
+    }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -36,8 +36,8 @@
         "uptime": "System Uptime",
         "days": "Days",
         "wan": "WAN",
-        "lan": "LAN",
-        "wlan": "WLAN",
+        "lan_users": "LAN Users",
+        "wlan_users": "WLAN Users",
         "up": "UP",
         "down": "DOWN",
         "wait": "Please wait"

--- a/src/utils/proxy/cached-fetch.js
+++ b/src/utils/proxy/cached-fetch.js
@@ -1,7 +1,12 @@
 import cache from "memory-cache";
 
+const defaultDuration = 5;
+
 export default async function cachedFetch(url, duration) {
   const cached = cache.get(url);
+
+  // eslint-disable-next-line no-param-reassign
+  duration = duration || defaultDuration;
 
   if (cached) {
     return cached;

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -15,9 +15,6 @@ export default function Component({ service }) {
         return <Container error={t("widget.api_error")} />;
     }
 
-    const wlanLabel = `${t("unifi.wlan")} ${t("unifi.users")}`
-    const lanLabel = `${t("unifi.lan")} ${t("unifi.users")}`
-
     const defaultSite = statsData?.data?.find(s => s.name === "default");
 
     if (!defaultSite) {
@@ -25,8 +22,8 @@ export default function Component({ service }) {
         <Container service={service}>
             <Block label="unifi.uptime" />
             <Block label="unifi.wan" />
-            <Block label={ lanLabel } />
-            <Block label={ wlanLabel } />
+            <Block label="unifi.lan_users" />
+            <Block label="unifi.wlan_users" />
         </Container>
         );
     }
@@ -45,7 +42,7 @@ export default function Component({ service }) {
         lan: {
             users: lan.num_user,
             status: lan.status
-        }
+        },
     };
 
     const uptime = `${t("common.number", { value: data.uptime / 86400, maximumFractionDigits: 1 })} ${t("unifi.days")}`;
@@ -54,8 +51,8 @@ export default function Component({ service }) {
         <Container service={service}>
             <Block label="unifi.uptime" value={ uptime } />
             <Block label="unifi.wan" value={ data.up ? t("unifi.up") : t("unifi.down") } />
-            <Block label={ lanLabel } value={t("common.number", { value: data.lan.users })} />
-            <Block label={ wlanLabel } value={t("common.number", { value: data.wlan.users })} />
+            <Block label="unifi.lan_users" value={ t("common.number", { value: data.lan.users }) } />
+            <Block label="unifi.wlan_users" value={ t("common.number", { value: data.wlan.users }) } />
         </Container>
     );
 }


### PR DESCRIPTION
- Needed to decompose i18n labels for Unifi widget in order for field visibility setting to work correctly
- Fixed weird edge case where a call to cached-fetch would fail if no duration was passed
- Have VS Code hide the .next and node_modules folders from tree view