### PR TITLE
Feature: Glances info widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -207,5 +207,10 @@
         "cpu": "CPU",
         "lxc": "LXC",
         "vms": "VMs"
+    },
+    "glances": {
+        "cpu": "CPU",
+        "mem": "MEM",
+        "wait": "Please wait"
     }
 }

--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -1,5 +1,4 @@
 import useSWR from "swr";
-
 import { BiError } from "react-icons/bi";
 import { FaMemory } from "react-icons/fa";
 import { FiCpu } from "react-icons/fi";

--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -1,0 +1,111 @@
+import useSWR from "swr";
+
+import { BiError } from "react-icons/bi";
+import { FaMemory } from "react-icons/fa";
+import { FiCpu } from "react-icons/fi";
+import { useTranslation } from "next-i18next";
+
+import UsageBar from "../resources/usage-bar";
+
+export default function Widget({ options }) {
+  const { t, i18n } = useTranslation();
+
+  const { data, error } = useSWR(
+    `/api/widgets/glances?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`, {
+      refreshInterval: 1500,
+    }
+  );
+
+  if (error || data?.error) {
+    return (
+      <div className="flex flex-col justify-center first:ml-0 ml-4">
+        <div className="flex flex-row items-center justify-end">
+          <div className="flex flex-row items-center">
+            <BiError className="w-8 h-8 text-theme-800 dark:text-theme-200" />
+            <div className="flex flex-col ml-3 text-left">
+              <span className="text-theme-800 dark:text-theme-200 text-sm">{t("widget.api_error")}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap ml-4">
+        <div className="flex flex-row self-center flex-wrap justify-between">
+           <div className="flex-none flex flex-row items-center mr-3 py-1.5">
+            <FiCpu className="text-theme-800 dark:text-theme-200 w-5 h-5" />
+            <div className="flex flex-col ml-3 text-left min-w-[85px]">
+              <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                <div className="pl-0.5 text-xs">
+                  {t("glances.wait")}
+                </div>
+              </div>
+              <UsageBar percent="0" />
+            </div>
+          </div>
+          <div className="flex-none flex flex-row items-center mr-3 py-1.5">
+            <FaMemory className="text-theme-800 dark:text-theme-200 w-5 h-5" />
+            <div className="flex flex-col ml-3 text-left min-w-[85px]">
+              <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                <div className="pl-0.5 text-xs">
+                  {t("glances.wait")}
+                </div>
+              </div>
+              <UsageBar percent="0" />
+            </div>
+          </div>
+        </div>
+        {options.label && (
+          <div className="ml-6 pt-1 text-center text-theme-800 dark:text-theme-200 text-xs">{options.label}</div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap ml-4">
+      <div className="flex flex-row self-center flex-wrap justify-between">
+         <div className="flex-none flex flex-row items-center mr-3 py-1.5">
+          <FiCpu className="text-theme-800 dark:text-theme-200 w-5 h-5" />
+          <div className="flex flex-col ml-3 text-left min-w-[85px]">
+            <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+              <div className="pl-0.5">
+                {t("common.number", {
+                  value: data.cpu,
+                  style: "unit",
+                  unit: "percent",
+                  maximumFractionDigits: 0,
+                })}
+              </div>
+              <div className="pr-1">{t("glances.cpu")}</div>
+            </div>
+            <UsageBar percent={data.cpu} />
+          </div>
+        </div>
+        <div className="flex-none flex flex-row items-center mr-3 py-1.5">
+          <FaMemory className="text-theme-800 dark:text-theme-200 w-5 h-5" />
+          <div className="flex flex-col ml-3 text-left min-w-[85px]">
+            <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+              <div className="pl-0.5">
+                {t("common.number", {
+                  value: data.mem,
+                  style: "unit",
+                  unit: "percent",
+                  maximumFractionDigits: 0,
+                })}
+              </div>
+              <div className="pr-1">{t("glances.mem")}</div>
+            </div>
+            <UsageBar percent={data.mem} />
+          </div>
+        </div>
+      </div>
+      {options.label && (
+        <div className="pt-1 text-center text-theme-800 dark:text-theme-200 text-xs">{options.label}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/widgets/widget.jsx
+++ b/src/components/widgets/widget.jsx
@@ -11,6 +11,7 @@ const widgetMappings = {
   datetime: dynamic(() => import("components/widgets/datetime/datetime")),
   logo: dynamic(() => import("components/widgets/logo/logo"), { ssr: false }),
   unifi_console: dynamic(() => import("components/widgets/unifi_console/unifi_console")),
+  glances: dynamic(() => import("components/widgets/glances/glances")),
 };
 
 export default function Widget({ widget }) {

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -1,12 +1,19 @@
 import { httpProxy } from "utils/proxy/http";
 import createLogger from "utils/logger";
+import { getSettings } from "utils/config/config";
 
 const logger = createLogger("glances");
 
 export default async function handler(req, res) {
-  const { url } = req.query;
+  const settings = getSettings()?.glances;
+  if (!settings) {
+    logger.error("There is no glances section in settings.yaml");
+    return res.status(400).json({ error: "There is no glances section in settings.yaml" });
+  }
   
+  const url = settings?.url;
   if (!url) {
+    logger.error("Missing Glances URL");
     return res.status(400).json({ error: "Missing Glances URL" });
   }
 

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -1,0 +1,23 @@
+import { httpProxy } from "utils/proxy/http";
+
+export default async function handler(req, res) {
+  const { url } = req.query;
+  
+  if (!url) {
+    return res.status(400).json({ error: "Missing Glances URL" });
+  }
+
+  const apiUrl = `${url}/api/3/quicklook`;
+  const params = { method: "GET", headers: {
+    "Accept-Encoding": "application/json"
+  } };
+
+  const [status, contentType, data, responseHeaders] = await httpProxy(apiUrl, params);
+
+  if (status !== 200) {
+    logger.error("HTTP %d getting data from glances API %s. Data: %s", status, apiUrl, data);
+  }
+
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(status).send(data);
+}

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -1,4 +1,7 @@
 import { httpProxy } from "utils/proxy/http";
+import createLogger from "utils/logger";
+
+const logger = createLogger("glances");
 
 export default async function handler(req, res) {
   const { url } = req.query;
@@ -12,7 +15,7 @@ export default async function handler(req, res) {
     "Accept-Encoding": "application/json"
   } };
 
-  const [status, contentType, data, responseHeaders] = await httpProxy(apiUrl, params);
+  const [status, contentType, data] = await httpProxy(apiUrl, params);
 
   if (status !== 200) {
     logger.error("HTTP %d getting data from glances API %s. Data: %s", status, apiUrl, data);

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -18,14 +18,22 @@ export default async function handler(req, res) {
   }
 
   const apiUrl = `${url}/api/3/quicklook`;
-  const params = { method: "GET", headers: {
+  const headers = {
     "Accept-Encoding": "application/json"
-  } };
+  };
+  if (settings.username && settings.password) {
+    headers.Authorization = `Basic ${Buffer.from(`${settings.username}:${settings.password}`).toString("base64")}`
+  }
+  const params = { method: "GET", headers };
 
   const [status, contentType, data] = await httpProxy(apiUrl, params);
 
+  if (status === 401) {
+    logger.error("Authorization failure getting data from glances API. Data: %s", data);
+  }
+
   if (status !== 200) {
-    logger.error("HTTP %d getting data from glances API %s. Data: %s", status, apiUrl, data);
+    logger.error("HTTP %d getting data from glances API. Data: %s", status, data);
   }
 
   if (contentType) res.setHeader("Content-Type", contentType);


### PR DESCRIPTION
One more! An info widget for [Glances](https://nicolargo.github.io/glances/) i.e. to remotely monitor another machine. Obviously this is built to match the `resources` info widget

<img width="275" alt="Screen Shot 2022-10-11 at 8 15 57 AM" src="https://user-images.githubusercontent.com/4887959/195131291-a356d1d7-a835-4c76-85e8-52f5c7926b7f.png">

- Uses the [quicklook](https://glances.readthedocs.io/en/latest/api.html#get-quicklook) endpoint to make it just one http call.
- ~~Moved `UsageBar` to a common folder to share with resources.~~
- Allows basic auth if enabled for glances
- Allows multiple instances with optional `id` property

Part of #125

`widgets.yaml`:
```yaml
- glances:
    id: glances1 # if using multiple instances
    label: RaspPi # optional
```

`settings.yaml`:
```yaml
- glances1: # if using multiple instances or just 'glances' for a single instance
    url: http://x.x.x.x:61208
    username: user # optional
    password: pass # optional
```