### PR TITLE
Fix: change Plex service widget to use "key" not "token"

### DIFF
--- a/src/widgets/plex/widget.js
+++ b/src/widgets/plex/widget.js
@@ -1,7 +1,7 @@
 import plexProxyHandler from "./proxy";
 
 const widget = {
-  api: "{url}{endpoint}?X-Plex-Token={token}",
+  api: "{url}{endpoint}?X-Plex-Token={key}",
   proxyHandler: plexProxyHandler,
 
   mappings: {


### PR DESCRIPTION
As discussed in https://github.com/benphelps/homepage/pull/366#issuecomment-1274247350

New `services.yaml`:
```yaml
    - Plex:
        href: https://app.plex.tv
        description: My Plex media server
        icon: plex.png
        widget:
            type: plex
            url: http://x.x.x.x:32400
            key: mytokenhere # see https://www.plexopedia.com/plex-media-server/general/plex-token/
```