### PR TITLE
Feature: Unified info widget settings

### DIFF
--- a/src/components/widgets/unifi_console/unifi_console.jsx
+++ b/src/components/widgets/unifi_console/unifi_console.jsx
@@ -10,7 +10,7 @@ export default function Widget({ options }) {
 
   // eslint-disable-next-line no-param-reassign
   options.type = "unifi_console";
-  const { data: statsData, error: statsError } = useWidgetAPI(options, "stat/sites");
+  const { data: statsData, error: statsError } = useWidgetAPI(options, "stat/sites", { index: options.index });
 
   if (statsError || statsData?.error) {
     return (

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -1,29 +1,17 @@
 import { httpProxy } from "utils/proxy/http";
 import createLogger from "utils/logger";
-import { getSettings } from "utils/config/config";
+import { getPrivateWidgetOptions } from "utils/config/service-helpers";
 
 const logger = createLogger("glances");
 
 export default async function handler(req, res) {
-  const { id } = req.query;
+  const { index } = req.query;
 
-  let errorMessage;
-
-  let instanceID = "glances";
-  if (id) { // multiple instances
-    instanceID = id;
-  }
-  const settings = getSettings();
-  const instanceSettings = settings[instanceID];
-  if (!instanceSettings) {
-    errorMessage = id ? `There is no glances section with id '${id}' in settings.yaml` : "There is no glances section in settings.yaml";
-    logger.error(errorMessage);
-    return res.status(400).json({ error: errorMessage });
-  }
+  const privateWidgetOptions = await getPrivateWidgetOptions("glances", index);
   
-  const url = instanceSettings?.url;
+  const url = privateWidgetOptions?.url;
   if (!url) {
-    errorMessage = "Missing Glances URL";
+    const errorMessage = "Missing Glances URL";
     logger.error(errorMessage);
     return res.status(400).json({ error: errorMessage });
   }
@@ -32,8 +20,8 @@ export default async function handler(req, res) {
   const headers = {
     "Accept-Encoding": "application/json"
   };
-  if (instanceSettings.username && instanceSettings.password) {
-    headers.Authorization = `Basic ${Buffer.from(`${instanceSettings.username}:${instanceSettings.password}`).toString("base64")}`
+  if (privateWidgetOptions.username && privateWidgetOptions.password) {
+    headers.Authorization = `Basic ${Buffer.from(`${privateWidgetOptions.username}:${privateWidgetOptions.password}`).toString("base64")}`
   }
   const params = { method: "GET", headers };
 

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -1,6 +1,6 @@
 import { httpProxy } from "utils/proxy/http";
 import createLogger from "utils/logger";
-import { getPrivateWidgetOptions } from "utils/config/service-helpers";
+import { getPrivateWidgetOptions } from "utils/config/widget-helpers";
 
 const logger = createLogger("glances");
 

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -4,7 +4,7 @@ import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig from "utils/config/config";
+import checkAndCopyConfig, { sanitizePrivateOptions } from "utils/config/config";
 import { servicesFromConfig, servicesFromDocker, cleanServiceGroups } from "utils/config/service-helpers";
 
 export async function bookmarksResponse() {
@@ -38,9 +38,12 @@ export async function widgetsResponse() {
   if (!widgets) return [];
 
   // map easy to write YAML objects into easy to consume JS arrays
-  const widgetsArray = widgets.map((group) => ({
+  const widgetsArray = widgets.map((group, index) => ({
     type: Object.keys(group)[0],
-    options: { ...group[Object.keys(group)[0]] },
+    options: {
+      index,
+      ...sanitizePrivateOptions(group[Object.keys(group)[0]])
+    },
   }));
 
   return widgetsArray;

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -4,8 +4,9 @@ import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { sanitizePrivateOptions } from "utils/config/config";
+import checkAndCopyConfig from "utils/config/config";
 import { servicesFromConfig, servicesFromDocker, cleanServiceGroups } from "utils/config/service-helpers";
+import { cleanWidgetGroups, widgetsFromConfig } from "utils/config/widget-helpers";
 
 export async function bookmarksResponse() {
   checkAndCopyConfig("bookmarks.yaml");
@@ -29,24 +30,17 @@ export async function bookmarksResponse() {
 }
 
 export async function widgetsResponse() {
-  checkAndCopyConfig("widgets.yaml");
+  let configuredWidgets;
 
-  const widgetsYaml = path.join(process.cwd(), "config", "widgets.yaml");
-  const fileContents = await fs.readFile(widgetsYaml, "utf8");
-  const widgets = yaml.load(fileContents);
+  try {
+    configuredWidgets = cleanWidgetGroups(await widgetsFromConfig());
+  } catch (e) {
+    console.error("Failed to load widgets, please check widgets.yaml for errors or remove example entries.");
+    if (e) console.error(e);
+    configuredWidgets = [];
+  }
 
-  if (!widgets) return [];
-
-  // map easy to write YAML objects into easy to consume JS arrays
-  const widgetsArray = widgets.map((group, index) => ({
-    type: Object.keys(group)[0],
-    options: {
-      index,
-      ...sanitizePrivateOptions(group[Object.keys(group)[0]])
-    },
-  }));
-
-  return widgetsArray;
+  return configuredWidgets;
 }
 
 export async function servicesResponse() {

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -34,16 +34,3 @@ export function getSettings() {
   const fileContents = readFileSync(settingsYaml, "utf8");
   return yaml.load(fileContents);
 }
-
-export function sanitizePrivateOptions(options, privateOnly = false) {
-  const privateOptions = ["url", "username", "password", "key"];
-  const sanitizedOptions = {};
-  Object.keys(options).forEach((key) => { 
-    if (!privateOnly && !privateOptions.includes(key)) {
-      sanitizedOptions[key] = options[key];
-    } else if (privateOnly && privateOptions.includes(key)) {
-      sanitizedOptions[key] = options[key];
-    }
-  });
-  return sanitizedOptions;
-}

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -34,3 +34,16 @@ export function getSettings() {
   const fileContents = readFileSync(settingsYaml, "utf8");
   return yaml.load(fileContents);
 }
+
+export function sanitizePrivateOptions(options, privateOnly = false) {
+  const privateOptions = ["url", "username", "password", "key"];
+  const sanitizedOptions = {};
+  Object.keys(options).forEach((key) => { 
+    if (!privateOnly && !privateOptions.includes(key)) {
+      sanitizedOptions[key] = options[key];
+    } else if (privateOnly && privateOptions.includes(key)) {
+      sanitizedOptions[key] = options[key];
+    }
+  });
+  return sanitizedOptions;
+}

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -5,7 +5,7 @@ import yaml from "js-yaml";
 import Docker from "dockerode";
 import * as shvl from "shvl";
 
-import checkAndCopyConfig from "utils/config/config";
+import checkAndCopyConfig, { sanitizePrivateOptions } from "utils/config/config";
 import getDockerArguments from "utils/config/docker";
 
 export async function servicesFromConfig() {
@@ -166,3 +166,22 @@ export default async function getServiceWidget(group, service) {
 
   return false;
 }
+
+export async function getPrivateWidgetOptions(type, index) {
+  checkAndCopyConfig("widgets.yaml");
+
+  const widgetsYaml = path.join(process.cwd(), "config", "widgets.yaml");
+  const fileContents = await fs.readFile(widgetsYaml, "utf8");
+  const widgets = yaml.load(fileContents);
+
+  if (!widgets) return [];
+
+  const privateOptions = widgets.map((group, widgetIndex) => ({
+    type: Object.keys(group)[0],
+    index: widgetIndex,
+    options: sanitizePrivateOptions(group[Object.keys(group)[0]], true),
+  }));
+
+  return (type !== undefined && index !== undefined) ? privateOptions.find(o => o.type === type && o.index === parseInt(index, 10))?.options : privateOptions;
+}
+  

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -5,7 +5,7 @@ import yaml from "js-yaml";
 import Docker from "dockerode";
 import * as shvl from "shvl";
 
-import checkAndCopyConfig, { sanitizePrivateOptions } from "utils/config/config";
+import checkAndCopyConfig from "utils/config/config";
 import getDockerArguments from "utils/config/docker";
 
 export async function servicesFromConfig() {
@@ -166,22 +166,3 @@ export default async function getServiceWidget(group, service) {
 
   return false;
 }
-
-export async function getPrivateWidgetOptions(type, index) {
-  checkAndCopyConfig("widgets.yaml");
-
-  const widgetsYaml = path.join(process.cwd(), "config", "widgets.yaml");
-  const fileContents = await fs.readFile(widgetsYaml, "utf8");
-  const widgets = yaml.load(fileContents);
-
-  if (!widgets) return [];
-
-  const privateOptions = widgets.map((group, widgetIndex) => ({
-    type: Object.keys(group)[0],
-    index: widgetIndex,
-    options: sanitizePrivateOptions(group[Object.keys(group)[0]], true),
-  }));
-
-  return (type !== undefined && index !== undefined) ? privateOptions.find(o => o.type === type && o.index === parseInt(index, 10))?.options : privateOptions;
-}
-  

--- a/src/utils/config/widget-helpers.js
+++ b/src/utils/config/widget-helpers.js
@@ -1,0 +1,73 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+import yaml from "js-yaml";
+
+import checkAndCopyConfig from "utils/config/config";
+
+export async function widgetsFromConfig() {
+    checkAndCopyConfig("widgets.yaml");
+
+    const widgetsYaml = path.join(process.cwd(), "config", "widgets.yaml");
+    const fileContents = await fs.readFile(widgetsYaml, "utf8");
+    const widgets = yaml.load(fileContents);
+
+    if (!widgets) return [];
+
+    // map easy to write YAML objects into easy to consume JS arrays
+    const widgetsArray = widgets.map((group, index) => ({
+        type: Object.keys(group)[0],
+        options: {
+            index,
+            ...group[Object.keys(group)[0]]
+        },
+    }));
+    return widgetsArray;
+}
+
+export async function cleanWidgetGroups(widgets) {
+    return widgets.map((widget, index) => {
+        const sanitizedOptions = widget.options;
+        const optionKeys = Object.keys(sanitizedOptions);
+        ["url", "username", "password", "key"].forEach((pO) => { 
+            if (optionKeys.includes(pO)) {
+                delete sanitizedOptions[pO];
+            }
+        });
+
+        return {
+            type: widget.type,
+            options: {
+                index,
+                ...sanitizedOptions
+            },
+        }
+    });
+}
+
+export async function getPrivateWidgetOptions(type, widgetIndex) {
+    const widgets = await widgetsFromConfig();
+  
+    const privateOptions = widgets.map((widget) => {
+        const {
+            index,
+            url,
+            username,
+            password,
+            key
+        } = widget.options;
+
+        return {
+            type: widget.type,
+            options: {
+                index,
+                url,
+                username,
+                password,
+                key
+            },
+        }
+    });
+  
+    return (type !== undefined && widgetIndex !== undefined) ? privateOptions.find(o => o.type === type && o.options.index === parseInt(widgetIndex, 10))?.options : privateOptions;
+}

--- a/src/widgets/unifi/proxy.js
+++ b/src/widgets/unifi/proxy.js
@@ -3,7 +3,8 @@ import cache from "memory-cache";
 import { formatApiCall } from "utils/proxy/api-helpers";
 import { httpProxy } from "utils/proxy/http";
 import { addCookieToJar, setCookieHeader } from "utils/proxy/cookie-jar";
-import getServiceWidget, { getPrivateWidgetOptions } from "utils/config/service-helpers";
+import getServiceWidget from "utils/config/service-helpers";
+import { getPrivateWidgetOptions } from "utils/config/widget-helpers";
 import createLogger from "utils/logger";
 import widgets from "widgets/widgets";
 

--- a/src/widgets/unifi/proxy.js
+++ b/src/widgets/unifi/proxy.js
@@ -3,8 +3,7 @@ import cache from "memory-cache";
 import { formatApiCall } from "utils/proxy/api-helpers";
 import { httpProxy } from "utils/proxy/http";
 import { addCookieToJar, setCookieHeader } from "utils/proxy/cookie-jar";
-import { getSettings } from "utils/config/config";
-import getServiceWidget from "utils/config/service-helpers";
+import getServiceWidget, { getPrivateWidgetOptions } from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import widgets from "widgets/widgets";
 
@@ -15,13 +14,13 @@ const logger = createLogger(proxyName);
 
 async function getWidget(req) {
   const { group, service, type } = req.query;
-
+  
   let widget = null;
-  if (type === "unifi_console") {
-    const settings = getSettings();
-    widget = settings.unifi_console;
+  if (type === "unifi_console") { // info widget
+    const index = req.query?.query ? JSON.parse(req.query.query).index : undefined;
+    widget = await getPrivateWidgetOptions(type, index);
     if (!widget) {
-      logger.debug("There is no unifi_console section in settings.yaml");
+      logger.debug("Error retrieving settings for this Unifi widget");
       return null;
     }
     widget.type = "unifi";


### PR DESCRIPTION
As discussed, this PR implements "unified" settings for info widgets. It also updates the `glances` and `unifi_console` info widgets to use this. Appreciate any input.

- Adds `getPrivateWidgetOptions` which optionally takes a widget type + index argument and returns... private widget options
- private settings (currently "url", "username", "password", "key") are removed from the widget options API response so theyre not passed as query vars

This allows for "unified" widgets.yaml (and multiple instances of a widget without needing `id` or anything), no settings.yaml needed 🎉

e.g. `widgets.yaml`:
```yaml
- glances:
    url: http://1.2.3.4:61208
    username: user
    password: pass
    label: RaspPi

- glances:
    url: http://5.6.7.8:61208
    username: user
    password: pass
    label: AnotherMachine

- unifi_console:
    url: https://9.10.11.12:443
    username: user
    password: pass
```