### PR TITLE
Add option to specify locale for datetime widget

### DIFF
--- a/src/components/widgets/datetime/datetime.jsx
+++ b/src/components/widgets/datetime/datetime.jsx
@@ -13,7 +13,7 @@ const textSizes = {
 };
 
 export default function DateTime({ options }) {
-  const { text_size: textSize, format } = options;
+  const { text_size: textSize, locale, format } = options;
   const { i18n } = useTranslation();
   const [date, setDate] = useState(new Date());
 
@@ -23,8 +23,9 @@ export default function DateTime({ options }) {
     }, 1000);
     return () => clearInterval(interval);
   }, [setDate]);
-
-  const dateFormat = new Intl.DateTimeFormat(i18n.language, { ...format });
+  
+  let region = locale !=== null ? locale : i18n.language
+  const dateFormat = new Intl.DateTimeFormat(region, { ...format });
 
   return (
     <div className="flex flex-row items-center grow justify-end">


### PR DESCRIPTION
I have found that i18n-next is wrongly setting the date in `en-US` format when it should be `en-GB`.

This should add an option to specify the locale, and then fall back if a value is not provided in the config:
```yaml
- datetime:
    text_size: sm
    locale: en-GB
    format:
      dateStyle: short
      timeStyle: short
      hour12: false
```