### PR TITLE
Feature: support target in individual services/bookmarks

### DIFF
--- a/src/components/bookmarks/item.jsx
+++ b/src/components/bookmarks/item.jsx
@@ -11,7 +11,7 @@ export default function Item({ bookmark }) {
       <a
         href={bookmark.href}
         title={bookmark.name}
-        target={settings.target ?? "_blank"}
+        target={settings.target ?? bookmark.target ?? "_blank"}
         className="block w-full text-left cursor-pointer transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10"
       >
         <div className="flex">

--- a/src/components/bookmarks/item.jsx
+++ b/src/components/bookmarks/item.jsx
@@ -11,7 +11,7 @@ export default function Item({ bookmark }) {
       <a
         href={bookmark.href}
         title={bookmark.name}
-        target={settings.target ?? bookmark.target ?? "_blank"}
+        target={bookmark.target ?? settings.target ?? "_blank"}
         className="block w-full text-left cursor-pointer transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10"
       >
         <div className="flex">

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -71,7 +71,7 @@ export default function Item({ service }) {
             (hasLink ? (
               <a
                 href={service.href}
-                target={settings.target ?? "_blank"}
+                target={settings.target ?? service.target ?? "_blank"}
                 rel="noreferrer"
                 className="flex-shrink-0 flex items-center justify-center w-12 "
               >
@@ -84,7 +84,7 @@ export default function Item({ service }) {
           {hasLink ? (
             <a
               href={service.href}
-              target={settings.target ?? "_blank"}
+              target={settings.target ?? service.target ?? "_blank"}
               rel="noreferrer"
               className="flex-1 flex items-center justify-between rounded-r-md "
             >

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -71,7 +71,7 @@ export default function Item({ service }) {
             (hasLink ? (
               <a
                 href={service.href}
-                target={settings.target ?? service.target ?? "_blank"}
+                target={service.target ?? settings.target ?? "_blank"}
                 rel="noreferrer"
                 className="flex-shrink-0 flex items-center justify-center w-12 "
               >
@@ -84,7 +84,7 @@ export default function Item({ service }) {
           {hasLink ? (
             <a
               href={service.href}
-              target={settings.target ?? service.target ?? "_blank"}
+              target={service.target ?? settings.target ?? "_blank"}
               rel="noreferrer"
               className="flex-1 flex items-center justify-between rounded-r-md "
             >


### PR DESCRIPTION
Allows the user to add `target:` to specific individual service and bookmarks, so it will treat specific links similar to the `target:` that can be set in the settings file.

An example service with this PR in mind would be:

```
- Apps:
    - Grafana:
        href: https://example.com/
        icon: grafana
        description: System statistics and graphs
        server: docker2
        target: _self
```

If no target is added in the service/bookmark,  it continues to default to `_blank` like it normally does.

Will need to update the wiki to add this information to the services and bookmark pages, if this is accepted. Thanks.