### PR TITLE
fixed issue causing preventing custom search from working

### DIFF
--- a/src/utils/config/widget-helpers.js
+++ b/src/utils/config/widget-helpers.js
@@ -29,7 +29,7 @@ export async function cleanWidgetGroups(widgets) {
     return widgets.map((widget, index) => {
         const sanitizedOptions = widget.options;
         const optionKeys = Object.keys(sanitizedOptions);
-        ["url", "username", "password", "key"].forEach((pO) => { 
+        ["username", "password", "key"].forEach((pO) => { 
             if (optionKeys.includes(pO)) {
                 delete sanitizedOptions[pO];
             }


### PR DESCRIPTION
When using custom search option, for example (search text=asdf):

```
- search:
    provider: custom
    url: https://qwant.com/?q=
    target: _blank
```

the the browser would try to redirect to `http(s)://myhost/undefinedasfe`. It appears this is because the `url` property is getting stripped out in the `cleanWidgetGroups` function. This causes the `url` property to get lost and not actually overwrite the `false` value set in `Search.jsx`