### PR TITLE
Basic support for Docker Swarm services

### DIFF
--- a/src/pages/api/docker/stats/[...service].js
+++ b/src/pages/api/docker/stats/[...service].js
@@ -31,18 +31,41 @@ export default async function handler(req, res) {
     const containerNames = containers.map((container) => container.Names[0].replace(/^\//, ""));
     const containerExists = containerNames.includes(containerName);
 
-    if (!containerExists) {
-      res.status(200).send({
-        error: "not found",
+    if (containerExists) {
+      const container = docker.getContainer(containerName);
+      const stats = await container.stats({ stream: false });
+
+      res.status(200).json({
+        stats,
       });
       return;
     }
 
-    const container = docker.getContainer(containerName);
-    const stats = await container.stats({ stream: false });
+    // Try with a service deployed in Docker Swarm
+    const tasks = await docker.listTasks({
+      filters: {
+        service: [containerName],
+        // A service can have several offline containers, so we only look for an active one.
+        'desired-state': ['running']
+      }
+    }).catch(() => []);
 
-    res.status(200).json({
-      stats,
+    // For now we are only interested in the first one (in case replicas > 1).
+    // TODO: Show the result for all replicas/containers?
+    const taskContainerId = tasks.at(0)?.Status?.ContainerStatus?.ContainerID
+
+    if (taskContainerId) {
+      const container = docker.getContainer(taskContainerId);
+      const stats = await container.stats({ stream: false });
+
+      res.status(200).json({
+        stats,
+      });
+      return;
+    }
+
+    res.status(200).send({
+      error: "not found",
     });
   } catch {
     res.status(500).send({

--- a/src/pages/api/docker/status/[...service].js
+++ b/src/pages/api/docker/status/[...service].js
@@ -29,17 +29,38 @@ export default async function handler(req, res) {
     const containerNames = containers.map((container) => container.Names[0].replace(/^\//, ""));
     const containerExists = containerNames.includes(containerName);
 
-    if (!containerExists) {
-      return res.status(200).send({
-        error: "not found",
+    if (containerExists) {
+      const container = docker.getContainer(containerName);
+      const info = await container.inspect();
+
+      return res.status(200).json({
+        status: info.State.Status,
       });
     }
 
-    const container = docker.getContainer(containerName);
-    const info = await container.inspect();
+    const tasks = await docker.listTasks({
+      filters: {
+        service: [containerName],
+        // A service can have several offline containers, we only look for an active one.
+        'desired-state': ['running']
+      }
+    }).catch(() => []);
 
-    return res.status(200).json({
-      status: info.State.Status,
+    // For now we are only interested in the first one (in case replicas > 1).
+    // TODO: Show the result for all replicas/containers?
+    const taskContainerId = tasks.at(0)?.Status?.ContainerStatus?.ContainerID
+
+    if (taskContainerId) {
+      const container = docker.getContainer(taskContainerId);
+      const info = await container.inspect();
+
+      return res.status(200).json({
+        status: info.State.Status,
+      });
+    }
+
+    return res.status(200).send({
+      error: "not found",
     });
   } catch {
     return res.status(500).send({


### PR DESCRIPTION
This PR adds basic support for obtaining the status and statistics of services deployed in Docker Swarm partially solving #348 

I have chosen to use almost the same method used to obtain this data for containers:

- Still using the `container` config parameter in `services.yaml`
- The new code is used as failover, i.e. if the container does not exist, it tries to find it as a Swarm service. At first glance I have not detected a considerable delay using this method, in any case maybe in the future it would be better to use a different config parameter to go directly to the new code.
- I have modified the code structure a little by choosing to enclose positive results in conditions leaving `error: "not found"` at the end.

---

It is possible to test the new code by creating the following files in the project directory:

`docker-compose.yml`
```yml
version: "3.8"

volumes:
  speedtest_data:

services:
  # Homepage
  homepage:
    image: homepage:latest
    restart: unless-stopped
    volumes:
      - ./data:/app/config
      - /var/run/docker.sock:/var/run/docker.sock
    ports:
      - "3000:3000"

  # Speedtest Tracker
  speedtest:
    image: henrywhitaker3/speedtest-tracker:latest
    restart: unless-stopped
    volumes:
      - speedtest_data:/config
    environment:
      - OOKLA_EULA_GDPR=true
    logging:
      driver: "json-file"
      options:
        max-file: "10"
        max-size: "200k"
```

`data/docker.yaml`
```yml
---
# For configuration options and examples, please see:
# https://github.com/benphelps/homepage/wiki/Docker-Integration

# my-docker:
#   host: 127.0.0.1
#   port: 2375

my-docker:
  socket: /var/run/docker.sock
```

`data/services.yaml`
```yml
---
# For configuration options and examples, please see:
# https://github.com/benphelps/homepage/wiki/Services

- My First Group:
    - Speedtest Tracker Service:
        server: my-docker
        container: homepage_speedtest
```

And then executing:

```sh
# Build Dockerfile and save the image locally
# Swarm mode does not allow the use of build: in docker-compose.yml
docker build --pull --rm -f Dockerfile -t homepage:latest .

# In case of not being in Swarm mode
docker swarm init

# Deploy on Swarm mode
docker stack deploy homepage -c docker-compose.yml
```

![](https://i.imgur.com/BUJtSMw.png)
