### PR TITLE
feature: add autobrr widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -292,5 +292,11 @@
         "up_to_date": "Up to Date",
         "child_bridges": "Child Bridges",
         "child_bridges_status": "{{ok}}/{{total}}"
+    },
+    "autobrr": {
+        "approvedPushes": "Approved",
+        "rejectedPushes": "Rejected",
+        "filters": "Filters",
+        "indexers": "Indexers"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -31,6 +31,8 @@ export default async function credentialedProxyHandler(req, res) {
         headers.Authorization = `Bearer ${widget.key}`;
       } else if (widget.type === "proxmox") {
         headers.Authorization = `PVEAPIToken=${widget.username}=${widget.password}`;
+      } else if (widget.type === "autobrr") {
+        headers["X-API-Token"] = `${widget.key}`;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/autobrr/component.jsx
+++ b/src/widgets/autobrr/component.jsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");
+  const { data: filtersData, error: filtersError } = useWidgetAPI(widget, "filters");
+  const { data: indexersData, error: indexersError } = useWidgetAPI(widget, "indexers");
+
+  if (statsError || filtersError || indexersError) {
+    return <Container error={t("widget.api_error")} />;
+  }
+
+  if (!statsData || !filtersData || !indexersData) {
+    return (
+      <Container service={service}>
+        <Block label="autobrr.approvedPushes" />
+        <Block label="autobrr.rejectedPushes" />
+        <Block label="autobrr.filters" />
+        <Block label="autobrr.indexers" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="autobrr.approvedPushes" value={t("common.number", { value: statsData.push_approved_count })} />
+      <Block label="autobrr.rejectedPushes" value={t("common.number", { value: statsData.push_rejected_count })} />
+      <Block label="autobrr.filters" value={t("common.number", { value: filtersData.length })} />
+      <Block label="autobrr.indexers" value={t("common.number", { value: indexersData.length })} />
+    </Container>
+  );
+}

--- a/src/widgets/autobrr/widget.js
+++ b/src/widgets/autobrr/widget.js
@@ -1,0 +1,20 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    stats: {
+      endpoint: "release/stats",
+    },
+    filters: {
+      endpoint: "filters",
+    },
+    indexers: {
+      endpoint: "release/indexers",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 const components = {
   adguard: dynamic(() => import("./adguard/component")),
   authentik: dynamic(() => import("./authentik/component")),
+  autobrr: dynamic(() => import("./autobrr/component")),
   bazarr: dynamic(() => import("./bazarr/component")),
   changedetectionio: dynamic(() => import("./changedetectionio/component")),
   coinmarketcap: dynamic(() => import("./coinmarketcap/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -1,5 +1,6 @@
 import adguard from "./adguard/widget";
 import authentik from "./authentik/widget";
+import autobrr from "./autobrr/widget";
 import bazarr from "./bazarr/widget";
 import changedetectionio from "./changedetectionio/widget";
 import coinmarketcap from "./coinmarketcap/widget";
@@ -35,6 +36,7 @@ import unifi from "./unifi/widget";
 const widgets = {
   adguard,
   authentik,
+  autobrr,
   bazarr,
   changedetectionio,
   coinmarketcap,


### PR DESCRIPTION
Adds widget support for autobrr

service.yaml example:

```
    - autobrr:
        icon: autobrr.png
        container: autobrr
        href: http://<url>:<port>
        description: the modern autodl-irssi replacement
        widget:
          type: autobrr
          url: http://<url>:<port>
          key: <api_key>
```

Preview:
![image](https://user-images.githubusercontent.com/2580736/198009469-4ec591a8-5b78-4de2-9d6d-6825d34b79c6.png)
