### PR TITLE
Feature: add Tube Archivist widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -303,5 +303,11 @@
         "rejectedPushes": "Rejected",
         "filters": "Filters",
         "indexers": "Indexers"
+    },
+    "tubearchivist": {
+        "downloads": "Queue",
+        "videos": "Videos",
+        "channels": "Channels",
+        "playlists": "Playlists"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -33,6 +33,8 @@ export default async function credentialedProxyHandler(req, res) {
         headers.Authorization = `PVEAPIToken=${widget.username}=${widget.password}`;
       } else if (widget.type === "autobrr") {
         headers["X-API-Token"] = `${widget.key}`;
+      } else if (widget.type === "tubearchivist") {
+        headers.Authorization = `Token ${widget.key}`;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -36,6 +36,7 @@ const components = {
   tautulli: dynamic(() => import("./tautulli/component")),
   traefik: dynamic(() => import("./traefik/component")),
   transmission: dynamic(() => import("./transmission/component")),
+  tubearchivist: dynamic(() => import("./tubearchivist/component")),
   unifi: dynamic(() => import("./unifi/component")),
   watchtower: dynamic(() => import("./watchtower/component")),
 };

--- a/src/widgets/tubearchivist/component.jsx
+++ b/src/widgets/tubearchivist/component.jsx
@@ -1,0 +1,40 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: downloadsData, error: downloadsError } = useWidgetAPI(widget, "downloads");
+  const { data: videosData, error: videosError } = useWidgetAPI(widget, "videos");
+  const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "channels");
+  const { data: playlistsData, error: playlistsError } = useWidgetAPI(widget, "playlists");
+
+  if (downloadsError || videosError || channelsError || playlistsError) {
+    return <Container error={t("widget.api_error")} />;
+  }
+
+  if (!downloadsData || !videosData || !channelsData || !playlistsData) {
+    return (
+      <Container service={service}>
+        <Block label="tubearchivist.downloads" />
+        <Block label="tubearchivist.videos" />
+        <Block label="tubearchivist.channels" />
+        <Block label="tubearchivist.playlists" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="tubearchivist.downloads" value={t("common.number", { value: downloadsData?.paginate?.total_hits })} />
+      <Block label="tubearchivist.videos" value={t("common.number", { value: videosData?.paginate?.total_hits })} />
+      <Block label="tubearchivist.channels" value={t("common.number", { value: channelsData?.paginate?.total_hits })} />
+      <Block label="tubearchivist.playlists" value={t("common.number", { value: playlistsData?.paginate?.total_hits })} />
+    </Container>
+  );
+}

--- a/src/widgets/tubearchivist/widget.js
+++ b/src/widgets/tubearchivist/widget.js
@@ -1,0 +1,23 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    downloads: {
+      endpoint: "download",
+    },
+    videos: {
+      endpoint: "video",
+    },
+    channels: {
+      endpoint: "channel",
+    },
+    playlists: {
+      endpoint: "playlist",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -31,6 +31,7 @@ import strelaysrv from "./strelaysrv/widget";
 import tautulli from "./tautulli/widget";
 import traefik from "./traefik/widget";
 import transmission from "./transmission/widget";
+import tubearchivist from "./tubearchivist/widget";
 import unifi from "./unifi/widget";
 import watchtower from './watchtower/widget'
 
@@ -69,6 +70,7 @@ const widgets = {
   tautulli,
   traefik,
   transmission,
+  tubearchivist,
   unifi,
   unifi_console: unifi,
   watchtower,


### PR DESCRIPTION
Adds widget support for [Tube Archivist](https://www.tubearchivist.com/)

service.yml example

```yml
    - Tube Archivist:
        icon: tube-archivist.png
        href: https://tubearchivist.example.com
        description: Your self hosted YouTube media server
        widget:
          type: tubearchivist
          url: https://tubearchivist.example.com
          key: <apikey>
          fields: ["downloads", "videos", "channels", "playlists"]
```

Screenshot:
![image](https://user-images.githubusercontent.com/2580736/199018679-d59ca27b-60e3-42a1-84f4-8be2dd9d5d7e.png)
