### PR TITLE
Add HDHomeRun widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -334,5 +334,9 @@
         "public_ip": "Public IP",
         "region": "Region",
         "country": "Country"
+    },
+    "hdhomerun": {
+        "channels": "Channels",
+        "hd": "HD"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -11,6 +11,7 @@ const components = {
   emby: dynamic(() => import("./emby/component")),
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),
+  hdhomerun: dynamic(() => import("./hdhomerun/component")),
   homebridge: dynamic(() => import("./homebridge/component")),
   jackett: dynamic(() => import("./jackett/component")),
   jellyfin: dynamic(() => import("./emby/component")),

--- a/src/widgets/hdhomerun/component.jsx
+++ b/src/widgets/hdhomerun/component.jsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup.json");
+
+  if (channelsError) {
+    return <Container error={t("widget.api_error")} />;
+  }
+
+  if (!channelsData) {
+    return (
+      <Container service={service}>
+        <Block label="hdhomerun.channels" />
+        <Block label="hdhomerun.hd" />
+      </Container>
+    );
+  }
+
+const hdChannels = channelsData?.filter((channel) => channel.HD === 1);
+
+  return (
+    <Container service={service}>
+      <Block label="hdhomerun.channels" value={channelsData.length } />
+      <Block label="hdhomerun.hd" value={hdChannels.length} />
+      
+    </Container>
+  );
+}

--- a/src/widgets/hdhomerun/component.jsx
+++ b/src/widgets/hdhomerun/component.jsx
@@ -9,7 +9,7 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup.json");
+  const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup");
 
   if (channelsError) {
     return <Container error={t("widget.api_error")} />;

--- a/src/widgets/hdhomerun/component.jsx
+++ b/src/widgets/hdhomerun/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup");
 
   if (channelsError) {
-    return <Container error={t("widget.api_error")} />;
+    return <Container error={channelsError} />;
   }
 
   if (!channelsData) {

--- a/src/widgets/hdhomerun/widget.js
+++ b/src/widgets/hdhomerun/widget.js
@@ -1,5 +1,4 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
-import { jsonArrayFilter } from "utils/proxy/api-helpers";
 
 const widget = {
   api: "{url}/{endpoint}",

--- a/src/widgets/hdhomerun/widget.js
+++ b/src/widgets/hdhomerun/widget.js
@@ -5,7 +5,7 @@ const widget = {
   proxyHandler: genericProxyHandler,
 
   mappings: {
-    "lineup.json": {
+    "lineup": {
       endpoint: "lineup.json",
     }
   },

--- a/src/widgets/hdhomerun/widget.js
+++ b/src/widgets/hdhomerun/widget.js
@@ -1,0 +1,15 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+import { jsonArrayFilter } from "utils/proxy/api-helpers";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    "lineup.json": {
+      endpoint: "lineup.json",
+    }
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -7,6 +7,7 @@ import coinmarketcap from "./coinmarketcap/widget";
 import emby from "./emby/widget";
 import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
+import hdhomerun from "./hdhomerun/widget";
 import homebridge from "./homebridge/widget";
 import jackett from "./jackett/widget";
 import jellyseerr from "./jellyseerr/widget";
@@ -49,6 +50,7 @@ const widgets = {
   emby,
   gluetun,
   gotify,
+  hdhomerun,
   homebridge,
   jackett,
   jellyfin: emby,


### PR DESCRIPTION
- Tracking Channels, and HD Channels
- Condensed API Calls into 1, per request in [earlier pr](https://github.com/benphelps/homepage/pull/481)

![firefox_XuWsRf9ia8](https://user-images.githubusercontent.com/460311/200044248-15fb909e-58c0-468e-ae91-059ef1f4899d.png)