### PR TITLE
Add Pyload widget

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -304,11 +304,5 @@
         "uptime": "Uptime",
         "alerts": "Alerts",
         "time": "{{value, number(style: unit; unitDisplay: long;)}}"
-    },
-    "pyload": {
-        "speed": "Geschwindigkeit",
-        "active": "Aktiv",
-        "queue": "Warteschlange",
-        "total": "Gesamt"
     }
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -292,5 +292,11 @@
         "containers_scanned": "Scanned",
         "containers_updated": "Updated",
         "containers_failed": "Failed"
+    },
+    "pyload": {
+        "speed": "Geschwindigkeit",
+        "active": "Aktiv",
+        "queue": "Warteschlange",
+        "total": "Gesamt"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -303,5 +303,11 @@
         "rejectedPushes": "Rejected",
         "filters": "Filters",
         "indexers": "Indexers"
+    },
+    "pyload": {
+        "speed": "Speed",
+        "active": "Active",
+        "queue": "Queue",
+        "total": "Total"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -25,6 +25,7 @@ const components = {
   portainer: dynamic(() => import("./portainer/component")),
   prowlarr: dynamic(() => import("./prowlarr/component")),
   proxmox: dynamic(() => import("./proxmox/component")),
+  pyload: dynamic(() => import("./pyload/component")),
   qbittorrent: dynamic(() => import("./qbittorrent/component")),
   radarr: dynamic(() => import("./radarr/component")),
   readarr: dynamic(() => import("./readarr/component")),

--- a/src/widgets/pyload/component.jsx
+++ b/src/widgets/pyload/component.jsx
@@ -7,13 +7,21 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { data: pyloadData, error: pyloadError } = useWidgetAPI(
-    widget,
-    "statusServer",
-  );
+  const { data: pyloadData, error: pyloadError } = useWidgetAPI(widget, "status");
 
-  if (pyloadError || !pyloadData) {
+  if (pyloadError || pyloadData?.error) {
     return <Container error={t("widget.api_error")} />;
+  }
+
+  if (!pyloadData) {
+    return (
+      <Container service={service}>
+        <Block label="pyload.speed" />
+        <Block label="pyload.active" />
+        <Block label="pyload.queue" />
+        <Block label="pyload.total" />
+      </Container>
+    );
   }
 
   return (

--- a/src/widgets/pyload/component.jsx
+++ b/src/widgets/pyload/component.jsx
@@ -1,19 +1,19 @@
 import { useTranslation } from 'next-i18next'
 
-import Container from 'components/services/widget/container'
-import Block from 'components/services/widget/block'
-import useWidgetAPI from 'utils/proxy/use-widget-api'
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
-  const { t } = useTranslation()
-  const { widget } = service
+  const { t } = useTranslation();
+  const { widget } = service;
   const { data: pyloadData, error: pyloadError } = useWidgetAPI(
     widget,
-    'statusServer',
-  )
+    "statusServer",
+  );
 
   if (pyloadError || !pyloadData) {
-    return <Container error={t('widget.api_error')} />
+    return <Container error={t("widget.api_error")} />;
   }
 
   return (
@@ -23,5 +23,5 @@ export default function Component({ service }) {
       <Block label="pyload.queue" value={t("common.number", { value: pyloadData.queue })} />
       <Block label="pyload.total" value={t("common.number", { value: pyloadData.total })} />
     </Container>
-  )
+  );
 }

--- a/src/widgets/pyload/component.jsx
+++ b/src/widgets/pyload/component.jsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'next-i18next'
+
+import Container from 'components/services/widget/container'
+import Block from 'components/services/widget/block'
+import useWidgetAPI from 'utils/proxy/use-widget-api'
+
+export default function Component({ service }) {
+  const { t } = useTranslation()
+  const { widget } = service
+  const { data: pyloadData, error: pyloadError } = useWidgetAPI(
+    widget,
+    'statusServer',
+  )
+
+  if (pyloadError || !pyloadData) {
+    return <Container error={t('widget.api_error')} />
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="pyload.speed" value={t("common.bitrate", { value: pyloadData.speed })} />
+      <Block label="pyload.active" value={t("common.number", { value: pyloadData.active })} />
+      <Block label="pyload.queue" value={t("common.number", { value: pyloadData.queue })} />
+      <Block label="pyload.total" value={t("common.number", { value: pyloadData.total })} />
+    </Container>
+  )
+}

--- a/src/widgets/pyload/proxy.js
+++ b/src/widgets/pyload/proxy.js
@@ -1,0 +1,38 @@
+import getServiceWidget from "utils/config/service-helpers";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import widgets from "widgets/widgets";
+
+export default async function pyloadProxyHandler(req, res) {
+  const { group, service, endpoint } = req.query;
+
+  if (group && service) {
+    const widget = await getServiceWidget(group, service);
+
+    if (widget) {
+      const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+      const loginUrl = `${widget.url}/api/login`;
+
+      // Pyload api does not support argument passing as JSON.
+      const sessionId = await fetch(loginUrl, {
+        method: "POST",
+        // Empty passwords are supported.
+        body: `username=${widget.username}&password=${widget.password ?? ''}`,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      }).then((response) => response.json());
+
+      const apiResponse = await fetch(url, {
+        method: "POST",
+        body: `session=${sessionId}`,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      }).then((response) => response.json());
+
+      return res.send(apiResponse);
+    }
+  }
+
+  return res.status(400).json({ error: "Invalid proxy service type" });
+}

--- a/src/widgets/pyload/proxy.js
+++ b/src/widgets/pyload/proxy.js
@@ -1,10 +1,10 @@
-import cache from "memory-cache";
+import cache from 'memory-cache';
 
-import getServiceWidget from "utils/config/service-helpers";
-import { formatApiCall } from "utils/proxy/api-helpers";
-import widgets from "widgets/widgets";
-import createLogger from "utils/logger";
-import { httpProxy } from "utils/proxy/http";
+import getServiceWidget from 'utils/config/service-helpers';
+import { formatApiCall } from 'utils/proxy/api-helpers';
+import widgets from 'widgets/widgets';
+import createLogger from 'utils/logger';
+import { httpProxy } from 'utils/proxy/http';
 
 const proxyName = 'pyloadProxyHandler';
 const logger = createLogger(proxyName);
@@ -12,24 +12,23 @@ const sessionCacheKey = `${proxyName}__sessionId`;
 
 async function fetchFromPyloadAPI(url, sessionId, params) {
   const options = {
-    method: "POST",
+    body: params
+      ? Object.keys(params)
+          .map((prop) => `${prop}=${params[prop]}`)
+          .join('&')
+      : `session=${sessionId}`,
+    method: 'POST',
     headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
+      'Content-Type': 'application/x-www-form-urlencoded',
     },
   };
 
-  if (params) {
-    options.body = Object.keys(params).map(k => `${k}=${params[k]}`).join('&');
-  } else {
-    options.body = `session=${sessionId}`;
-  }
-  
   // eslint-disable-next-line no-unused-vars
   const [status, contentType, data] = await httpProxy(url, options);
   return [status, JSON.parse(Buffer.from(data).toString())];
 }
 
-async function login(loginUrl, username, password) {
+async function login(loginUrl, username, password = '') {
   const [status, sessionId] = await fetchFromPyloadAPI(loginUrl, null, { username, password });
   if (status !== 200) {
     throw new Error(`HTTP error ${status} logging into Pyload API, returned: ${sessionId}`);
@@ -45,26 +44,21 @@ export default async function pyloadProxyHandler(req, res) {
   try {
     if (group && service) {
       const widget = await getServiceWidget(group, service);
-  
+
       if (widget) {
         const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
         const loginUrl = `${widget.url}/api/login`;
-  
-        let sessionId = cache.get(sessionCacheKey);
 
-        if (!sessionId) {
-          sessionId = await login(loginUrl, widget.username, widget.password);
-        }
-  
+        let sessionId = cache.get(sessionCacheKey) ?? await login(loginUrl, widget.username, widget.password);
         let [status, data] = await fetchFromPyloadAPI(url, sessionId);
 
         if (status === 403) {
-          logger.debug("Failed to retrieve data from Pyload API, login and re-try");
+          logger.debug('Failed to retrieve data from Pyload API, login and re-try');
           cache.del(sessionCacheKey);
           sessionId = await login(loginUrl, widget.username, widget.password);
           [status, data] = await fetchFromPyloadAPI(url, sessionId);
         }
-        
+
         if (data?.error || status !== 200) {
           return res.status(500).send(Buffer.from(data).toString());
         }
@@ -77,5 +71,5 @@ export default async function pyloadProxyHandler(req, res) {
     return res.status(500).send(e.toString());
   }
 
-  return res.status(400).json({ error: "Invalid proxy service type" });
+  return res.status(400).json({ error: 'Invalid proxy service type' });
 }

--- a/src/widgets/pyload/proxy.js
+++ b/src/widgets/pyload/proxy.js
@@ -1,6 +1,36 @@
+import cache from "memory-cache";
+
 import getServiceWidget from "utils/config/service-helpers";
 import { formatApiCall } from "utils/proxy/api-helpers";
 import widgets from "widgets/widgets";
+import createLogger from "utils/logger";
+
+const proxyName = 'pyloadProxyHandler';
+const logger = createLogger(proxyName);
+const sessionCacheKey = `${proxyName}__sessionId`;
+
+async function fetchFromPyloadAPI(url, sessionId, params) {
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  };
+
+  if (params) {
+    options.body = Object.keys(params).map(k => `${k}=${params[k]}`).join('&');
+  } else {
+    options.body = `session=${sessionId}`
+  }
+  
+  return fetch(url, options).then((response) => response.json());
+}
+
+async function login(loginUrl, username, password) {
+  const sessionId = await fetchFromPyloadAPI(loginUrl, null, { username, password })
+  cache.put(sessionCacheKey, sessionId);
+  return sessionId;
+}
 
 export default async function pyloadProxyHandler(req, res) {
   const { group, service, endpoint } = req.query;
@@ -12,24 +42,26 @@ export default async function pyloadProxyHandler(req, res) {
       const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
       const loginUrl = `${widget.url}/api/login`;
 
-      // Pyload api does not support argument passing as JSON.
-      const sessionId = await fetch(loginUrl, {
-        method: "POST",
-        // Empty passwords are supported.
-        body: `username=${widget.username}&password=${widget.password ?? ''}`,
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-      }).then((response) => response.json());
+      let sessionId = cache.get(sessionCacheKey);
 
-      const apiResponse = await fetch(url, {
-        method: "POST",
-        body: `session=${sessionId}`,
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-      }).then((response) => response.json());
+      if (!sessionId) {
+        sessionId = await login(loginUrl, widget.username, widget.password);
+      }
 
+      let apiResponse = await fetchFromPyloadAPI(url, sessionId);
+
+      if (apiResponse?.error === 'Forbidden') {
+        logger.debug("Failed to retrieve data from Pyload API, login and re-try");
+        cache.del(sessionCacheKey);
+        sessionId = await login(loginUrl, widget.username, widget.password);
+        apiResponse = await fetchFromPyloadAPI(url, sessionId);
+      }
+      
+      if (apiResponse?.error) {
+        return res.status(500).send(apiResponse);
+      }
+      cache.del(sessionCacheKey);
+      
       return res.send(apiResponse);
     }
   }

--- a/src/widgets/pyload/widget.js
+++ b/src/widgets/pyload/widget.js
@@ -3,6 +3,12 @@ import pyloadProxyHandler from "./proxy";
 const widget = {
   api: "{url}/api/{endpoint}",
   proxyHandler: pyloadProxyHandler,
-};
+
+  mappings: {
+    "status": {
+      endpoint: "statusServer",
+    }
+  }
+}
 
 export default widget;

--- a/src/widgets/pyload/widget.js
+++ b/src/widgets/pyload/widget.js
@@ -1,0 +1,8 @@
+import pyloadProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: pyloadProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -20,6 +20,7 @@ import plex from "./plex/widget";
 import portainer from "./portainer/widget";
 import prowlarr from "./prowlarr/widget";
 import proxmox from "./proxmox/widget";
+import pyload from "./pyload/widget";
 import qbittorrent from "./qbittorrent/widget";
 import radarr from "./radarr/widget";
 import readarr from "./readarr/widget";
@@ -58,6 +59,7 @@ const widgets = {
   portainer,
   prowlarr,
   proxmox,
+  pyload,
   qbittorrent,
   radarr,
   readarr,


### PR DESCRIPTION
Adds a simple widget for monitoring [Pyload](https://github.com/pyload/pyload/) downloads.

![image](https://user-images.githubusercontent.com/26797810/200165144-4a21306b-2fc2-4056-b22c-7b309e77defe.png)

possible fields:
- speed
- active
- queue
- total

example config:
```yaml
- Pyload:
        icon: /icons/pyload.png
        href: http://home:8668/
        description: Download Manager
        container: pyload
        widget:
            type: pyload
            url: http://home:8668
            username: secure_monitor
            password: super!secret
```
The pyload user in question needs at least "LIST" permissions.
Empty passwords are also supported. So you can create a monitoring user with only "LIST" permissions and no password.

This would look like this in the config:
```yaml
widget:
    type: pyload
    url: http://home:8668
    username: monitor
```