### PR TITLE
Feature: add navidrome support

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -169,10 +169,8 @@
         "middleware": "Middleware"
     },
     "navidrome": {
-        "user": "User",
-        "artist": "Artist",
-        "song": "Song",
-        "album": "Album"
+        "nothing_streaming": "No Active Streams",
+        "please_wait": "Please Wait"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -168,6 +168,12 @@
         "services": "Services",
         "middleware": "Middleware"
     },
+    "navidrome": {
+        "user": "User",
+        "artist": "Artist",
+        "song": "Song",
+        "album": "Album"
+    },
     "npm": {
         "enabled": "Enabled",
         "disabled": "Disabled",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -16,6 +16,7 @@ const components = {
   jellyseerr: dynamic(() => import("./jellyseerr/component")),
   lidarr: dynamic(() => import("./lidarr/component")),
   mastodon: dynamic(() => import("./mastodon/component")),
+  navidrome: dynamic(() => import("./navidrome/component")),
   npm: dynamic(() => import("./npm/component")),
   nzbget: dynamic(() => import("./nzbget/component")),
   ombi: dynamic(() => import("./ombi/component")),

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -11,11 +11,11 @@ export default function Component({ service }) {
 
   const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, "getNowPlaying");
 
-  if (navidromeError) {
+  if (navidromeError || navidromeData?.error || navidromeData?.["subsonic-response"]?.error) {
     return <Container error={t("widget.api_error")} />;
   }
 
-  if (!navidromeData || Object.keys(navidromeData["subsonic-response"].nowPlaying).length === 0) {
+  if (!navidromeData) {
     return (
       <Container service={service}>
         <Block label="navidrome.user" />
@@ -26,10 +26,18 @@ export default function Component({ service }) {
     );
   }
 
-  const nowPlaying = Object.values(navidromeData["subsonic-response"].nowPlaying.entry);
+  const nowPlaying = navidromeData["subsonic-response"].nowPlaying;
+  if (!nowPlaying.entry) {
+    // nothing playing
+    return (
+      <Container service={service} />
+    );
+  }
+
+  const nowPlayingEntries = Object.values(nowPlaying.entry);
   const songList = [];
 
-  nowPlaying.forEach(userPlay => {
+  nowPlayingEntries.forEach(userPlay => {
       const playing = (
         <Container service={service}>
           <Block label="navidrome.user" value={userPlay.username} />

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -1,0 +1,45 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, "getNowPlaying");
+
+  if (navidromeError) {
+    return <Container error={t("widget.api_error")} />;
+  }
+
+  if (!navidromeData || Object.keys(navidromeData["subsonic-response"].nowPlaying).length === 0) {
+    return (
+      <Container service={service}>
+        <Block label="navidrome.user" />
+        <Block label="navidrome.artist" />
+        <Block label="navidrome.song" />
+        <Block label="navidrome.album" />
+      </Container>
+    );
+  }
+
+  const nowPlaying = Object.values(navidromeData["subsonic-response"].nowPlaying.entry);
+  const songList = [];
+
+  nowPlaying.forEach(userPlay => {
+      const playing = (
+        <Container service={service}>
+          <Block label="navidrome.user" value={userPlay.username} />
+          <Block label="navidrome.artist" value={userPlay.artist} />
+          <Block label="navidrome.song" value={userPlay.title} />
+          <Block label="navidrome.album" value={userPlay.album} />
+        </Container>
+      );
+      songList.unshift(playing);
+    });
+
+  return songList;
+}

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -1,8 +1,23 @@
 import { useTranslation } from "next-i18next";
 
 import Container from "components/services/widget/container";
-import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function SinglePlayingEntry({ entry }) {
+  const { username, artist, title, album } = entry;
+  let fullTitle = title;
+  if (artist) fullTitle = `${artist} - ${title}`;
+  if (album) fullTitle += ` — ${album}`;
+  if (username) fullTitle += ` (${username})`;
+
+  return (
+    <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
+      <div className="text-xs z-10 self-center ml-2 relative w-full h-4 grow mr-2">
+        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">{fullTitle}</div>
+      </div>
+    </div>
+  );
+}
 
 export default function Component({ service }) {
   const { t } = useTranslation();
@@ -17,37 +32,25 @@ export default function Component({ service }) {
 
   if (!navidromeData) {
     return (
-      <Container service={service}>
-        <Block label="navidrome.user" />
-        <Block label="navidrome.artist" />
-        <Block label="navidrome.song" />
-        <Block label="navidrome.album" />
-      </Container>
+      <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />
     );
   }
 
-  const nowPlaying = navidromeData["subsonic-response"].nowPlaying;
+  const { nowPlaying } = navidromeData["subsonic-response"];
   if (!nowPlaying.entry) {
     // nothing playing
     return (
-      <Container service={service} />
+      <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />
     );
   }
 
   const nowPlayingEntries = Object.values(nowPlaying.entry);
-  const songList = [];
 
-  nowPlayingEntries.forEach(userPlay => {
-      const playing = (
-        <Container service={service}>
-          <Block label="navidrome.user" value={userPlay.username} />
-          <Block label="navidrome.artist" value={userPlay.artist} />
-          <Block label="navidrome.song" value={userPlay.title} />
-          <Block label="navidrome.album" value={userPlay.album} />
-        </Container>
-      );
-      songList.unshift(playing);
-    });
-
-  return songList;
+  return (
+    <div className="flex flex-col pb-1 mx-1">
+      {nowPlayingEntries.map((entry) => (
+        <SinglePlayingEntry key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
 }

--- a/src/widgets/navidrome/widget.js
+++ b/src/widgets/navidrome/widget.js
@@ -1,7 +1,7 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v={version}&c={client}&f=json",
+  api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v=1.16.1&c=homepage&f=json",
   proxyHandler: genericProxyHandler,
 
   mappings: {

--- a/src/widgets/navidrome/widget.js
+++ b/src/widgets/navidrome/widget.js
@@ -1,0 +1,14 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v={version}&c={client}&f=json",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    "getNowPlaying": {
+      endpoint: "getNowPlaying",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -11,6 +11,7 @@ import jackett from "./jackett/widget";
 import jellyseerr from "./jellyseerr/widget";
 import lidarr from "./lidarr/widget";
 import mastodon from "./mastodon/widget";
+import navidrome from "./navidrome/widget";
 import npm from "./npm/widget";
 import nzbget from "./nzbget/widget";
 import ombi from "./ombi/widget";
@@ -51,6 +52,7 @@ const widgets = {
   jellyseerr,
   lidarr,
   mastodon,
+  navidrome,
   npm,
   nzbget,
   ombi,


### PR DESCRIPTION
This PR adds initial support for displaying now playing song information from Navidrome using the Subsonic API. The widget will display the currently-playing song for all users currently connected to the provided Navidrome server.

### Configuration

`services.yaml`
```yaml
- Navidrome
    icon: navidrome.png
    href: http://<url>:<port>
    description: Bangers and Kool-Aid Jammers
    widget:
      type: navidrome
      url: http://<url>:<port>
      user: <user>
      token: <token>
      salt: <salt>
```

For example:
```yaml
- Navidrome
    icon: navidrome.png
    href: http://localhost:4533
    description: Bangers and Kool-Aid Jammers
    widget:
      type: navidrome
      url: http://localhost:4533
      user: navidrome
      token: 9e686d7eb61b8639642c6dfc26b23c7e
      salt: ca976fd9
```

### Generating salt and token values

Navidrome currently supports Subsonic API version 1.16.1: https://www.navidrome.org/docs/developers/subsonic-api/

For detailed information on how to generate salt and token values for authentication, see the Subsonic API documentation page: http://www.subsonic.org/pages/api.jsp

### Preview

<img width="549" alt="homepage-navidrome-example" src="https://user-images.githubusercontent.com/77213414/200364825-38d2aa4c-4f00-4d26-8c94-764674a59805.png">
