### PR TITLE
Add gluetun widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -325,5 +325,10 @@
         "active": "Active",
         "queue": "Queue",
         "total": "Total"
+    },
+    "gluetun": {
+        "public_ip": "Public IP",
+        "region": "Region",
+        "country": "Country"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -9,6 +9,7 @@ const components = {
   coinmarketcap: dynamic(() => import("./coinmarketcap/component")),
   docker: dynamic(() => import("./docker/component")),
   emby: dynamic(() => import("./emby/component")),
+  gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),
   homebridge: dynamic(() => import("./homebridge/component")),
   jackett: dynamic(() => import("./jackett/component")),

--- a/src/widgets/gluetun/component.jsx
+++ b/src/widgets/gluetun/component.jsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: gluetunData, error: gluetunError } = useWidgetAPI(widget, "ip");
+
+  if (gluetunError) {
+    return <Container error={t("widget.api_error")} />;
+  }
+
+  if (!gluetunData) {
+    return (
+      <Container service={service}>
+        <Block label="gluetun.public_ip" />
+        <Block label="gluetun.region" />
+        <Block label="gluetun.country" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="gluetun.public_ip" value={gluetunData.public_ip} />
+      <Block label="gluetun.region" value={gluetunData.region} />
+      <Block label="gluetun.country" value={gluetunData.country} />
+    </Container>
+  );
+}

--- a/src/widgets/gluetun/widget.js
+++ b/src/widgets/gluetun/widget.js
@@ -1,0 +1,14 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/v1/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    ip: {
+      endpoint: "publicip/ip",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -5,6 +5,7 @@ import bazarr from "./bazarr/widget";
 import changedetectionio from "./changedetectionio/widget";
 import coinmarketcap from "./coinmarketcap/widget";
 import emby from "./emby/widget";
+import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
 import homebridge from "./homebridge/widget";
 import jackett from "./jackett/widget";
@@ -46,6 +47,7 @@ const widgets = {
   changedetectionio,
   coinmarketcap,
   emby,
+  gluetun,
   gotify,
   homebridge,
   jackett,


### PR DESCRIPTION
Added widget to support [gluetun](https://github.com/qdm12/gluetun) information:

Configuration:

```
- Gluetun:
    icon: /icons/pipe.png
    href: https://gluetun.mydomain.com
    description: VPN Client
    widget:
      type: gluetun
      url: https://gluetun.mydomain.com
```

Preview:

![Gluetun_Widget](https://user-images.githubusercontent.com/15030658/200883318-9ab6b81c-6b3a-4bdc-a35f-23e855d1a4b4.png)
