### PR TITLE
Added configurable setting for log folder

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 import { join } from "path";
 import { format as utilFormat } from "node:util";
-import checkAndCopyConfig, { getSettings } from "utils/config/config";
 
 import winston from "winston";
+
+import checkAndCopyConfig, { getSettings } from "utils/config/config";
 
 let winstonLogger;
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { join } from "path";
 import { format as utilFormat } from "node:util";
+import checkAndCopyConfig, { getSettings } from "utils/config/config";
 
 import winston from "winston";
 
@@ -8,6 +9,9 @@ let winstonLogger;
 
 function init() {
   const configPath = join(process.cwd(), "config");
+  checkAndCopyConfig("settings.yaml");
+  const settings = getSettings();
+  const logpath = settings.logpath || configPath;
 
   function combineMessageAndSplat() {
     return {
@@ -57,7 +61,7 @@ function init() {
           winston.format.timestamp(),
           winston.format.printf(messageFormatter)
         ),
-        filename: `${configPath}/logs/homepage.log`,
+        filename: `${logpath}/logs/homepage.log`,
         handleExceptions: true,
         handleRejections: true,
       }),


### PR DESCRIPTION
Added a setting `logpath` that when set, will allow the administrator to specify a log location on disk. If not set, the value will remain the config directory as before.

Why necessary:

1) Its a best practice to be able to configure the log place.
2) Logs probably shouldn't be stored in the config directory.
3) For certain platforms, the config directory might not be writable, no widgets appear to work when this is the case