### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+
+RUN npm install -g pnpm
+
+ENV PATH="${PATH}:./node_modules/.bin"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "homepage",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "18-buster"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"mhutchie.git-graph",
+				"streetsidesoftware.code-spell-checker",
+			],
+			"settings": {
+				"eslint.format.enable": true,
+				"eslint.lintTask.enable": true,
+				"eslint.packageManager": "pnpm"
+			}
+		}
+	},
+	"postCreateCommand": ".devcontainer/setup.sh",
+	"forwardPorts": [
+		3000
+	]
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Install Node packages
+pnpm install
+
+# Copy in skeleton configuration if there is no existing configuration
+if [ ! -d "config/" ]; then
+  echo "Adding skeleton config"
+  mkdir config/
+  cp -r src/skeleton/* config
+fi


### PR DESCRIPTION
devcontainers can be used by IDEs like VSCode to build the whole development environment in a container. This allows you to keep dependencies, build, and all development aspects separated from any development. It also allows contributors to instantly have a working, standardized development environment. It also allows cloud development tools like GitHub Codespaces be automatically setup with the desired environment.

See https://containers.dev/ for more details