### PR TITLE
Add scrutiny widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -344,5 +344,10 @@
     "hdhomerun": {
         "channels": "Channels",
         "hd": "HD"
+    },
+    "scrutiny": {
+        "passed": "Passed",
+        "failed": "Failed",
+        "unknown": "Unknown"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -34,6 +34,7 @@ const components = {
   readarr: dynamic(() => import("./readarr/component")),
   rutorrent: dynamic(() => import("./rutorrent/component")),
   sabnzbd: dynamic(() => import("./sabnzbd/component")),
+  scrutiny: dynamic(() => import("./scrutiny/component")),
   sonarr: dynamic(() => import("./sonarr/component")),
   speedtest: dynamic(() => import("./speedtest/component")),
   strelaysrv: dynamic(() => import("./strelaysrv/component")),

--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -1,0 +1,37 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: scrutinyData, error: scrutinyError } = useWidgetAPI(widget, "summary");
+
+  if (scrutinyError) {
+    return <Container error={scrutinyError} />;
+  }
+
+  if (!scrutinyData) {
+    return (
+      <Container service={service}>
+        <Block label="scrutiny.passed" />
+        <Block label="scrutiny.failed" />
+        <Block label="scrutiny.unknown" />
+      </Container>
+    );
+  }
+
+  const deviceIds = Object.values(scrutinyData.data.summary);
+  
+  const passed = deviceIds.filter(deviceId => deviceId.device.device_status === 0)?.length || 0;
+  const failed = deviceIds.filter(deviceId => deviceId.device.device_status > 0 && deviceId.device.device_status <= 3)?.length || 0;
+  const unknown = deviceIds.length - (passed + failed) || 0;
+
+  return (
+    <Container service={service}>
+      <Block label="scrutiny.passed" value={passed} />
+      <Block label="scrutiny.failed" value={failed} />
+      <Block label="scrutiny.unknown" value={unknown} />
+    </Container>
+  );
+}

--- a/src/widgets/scrutiny/widget.js
+++ b/src/widgets/scrutiny/widget.js
@@ -1,0 +1,17 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    summary: {
+      endpoint: "summary",
+      validate: [
+        "data",
+      ]
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -29,6 +29,7 @@ import radarr from "./radarr/widget";
 import readarr from "./readarr/widget";
 import rutorrent from "./rutorrent/widget";
 import sabnzbd from "./sabnzbd/widget";
+import scrutiny from "./scrutiny/widget";
 import sonarr from "./sonarr/widget";
 import speedtest from "./speedtest/widget";
 import strelaysrv from "./strelaysrv/widget";
@@ -73,6 +74,7 @@ const widgets = {
   readarr,
   rutorrent,
   sabnzbd,
+  scrutiny,
   sonarr,
   speedtest,
   strelaysrv,


### PR DESCRIPTION
Added widget to support [scrutiny](https://github.com/AnalogJ/scrutiny) information:

Configuration:

```
  - Scrutiny:
      icon: scrutiny.png
      href: https://scrutiny.mydomain.com
      description: Hard Drive Monitoring
      widget:
        type: scrutiny
        url: https://scrutiny.mydomain.com
```

Preview:

![Scrutiny Widget](https://user-images.githubusercontent.com/15030658/203578603-9ef2037a-f8da-43d8-9b30-961b73715edc.png)

