### PR TITLE
Add paperless-ngx widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -349,5 +349,9 @@
         "passed": "Passed",
         "failed": "Failed",
         "unknown": "Unknown"
+    },
+    "paperlessngx": {
+        "inbox": "Inbox",
+        "total": "Total"
     }
 }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -118,6 +118,7 @@ export function cleanServiceGroups(groups) {
           container,
           currency, // coinmarketcap widget
           symbols,
+          inboxTag, // paperlessngx widget
         } = cleanedService.widget;
 
         cleanedService.widget = {
@@ -129,6 +130,8 @@ export function cleanServiceGroups(groups) {
 
         if (currency) cleanedService.widget.currency = currency;
         if (symbols) cleanedService.widget.symbols = symbols;
+        
+        if (inboxTag) cleanedService.widget.inboxTag = inboxTag;
 
         if (type === "docker") {
           if (server) cleanedService.widget.server = server;

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -118,7 +118,6 @@ export function cleanServiceGroups(groups) {
           container,
           currency, // coinmarketcap widget
           symbols,
-          inboxTag, // paperlessngx widget
         } = cleanedService.widget;
 
         cleanedService.widget = {
@@ -130,8 +129,6 @@ export function cleanServiceGroups(groups) {
 
         if (currency) cleanedService.widget.currency = currency;
         if (symbols) cleanedService.widget.symbols = symbols;
-        
-        if (inboxTag) cleanedService.widget.inboxTag = inboxTag;
 
         if (type === "docker") {
           if (server) cleanedService.widget.server = server;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -23,6 +23,7 @@ const components = {
   nzbget: dynamic(() => import("./nzbget/component")),
   ombi: dynamic(() => import("./ombi/component")),
   overseerr: dynamic(() => import("./overseerr/component")),
+  paperlessngx: dynamic(() => import("./paperlessngx/component")),
   pihole: dynamic(() => import("./pihole/component")),
   plex: dynamic(() => import("./plex/component")),
   portainer: dynamic(() => import("./portainer/component")),

--- a/src/widgets/paperlessngx/component.jsx
+++ b/src/widgets/paperlessngx/component.jsx
@@ -5,26 +5,13 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 export default function Component({ service }) {
   const { widget } = service;
 
-  const { data: inboxData, error: inboxError } = useWidgetAPI(widget, "inbox",
-  {
-    query: `tag:${widget.inboxTag}`,
-    format: "json",
-    fields: "count"
-  });
+  const { data: statisticsData, error: statisticsError } = useWidgetAPI(widget, "statistics");
 
-
-  const { data: documentData, error: documentError } = useWidgetAPI(widget, "documents",
-  {
-    fields: "count",
-    format: "json",
-  });
-
-  if (inboxError || documentError) {
-    const finalError = inboxError ?? documentError;
-    return <Container error={finalError} />;
+  if (statisticsError) {
+    return <Container error={statisticsError} />;
   }
 
-  if (!inboxData || !documentData) {
+  if (!statisticsData) {
     return (
       <Container service={service}>
         <Block label="paperlessngx.inbox" />
@@ -35,8 +22,8 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="paperlessngx.inbox" value={inboxData.count} />
-      <Block label="paperlessngx.total" value={documentData.count} />
+      {statisticsData.documents_inbox !== undefined && <Block label="paperlessngx.inbox" value={statisticsData.documents_inbox} />}
+      <Block label="paperlessngx.total" value={statisticsData.documents_total} />
     </Container>
   );
 }

--- a/src/widgets/paperlessngx/component.jsx
+++ b/src/widgets/paperlessngx/component.jsx
@@ -1,0 +1,42 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: inboxData, error: inboxError } = useWidgetAPI(widget, "inbox",
+  {
+    query: `tag:${widget.inboxTag}`,
+    format: "json",
+    fields: "count"
+  });
+
+
+  const { data: documentData, error: documentError } = useWidgetAPI(widget, "documents",
+  {
+    fields: "count",
+    format: "json",
+  });
+
+  if (inboxError || documentError) {
+    const finalError = inboxError ?? documentError;
+    return <Container error={finalError} />;
+  }
+
+  if (!inboxData || !documentData) {
+    return (
+      <Container service={service}>
+        <Block label="paperlessngx.inbox" />
+        <Block label="paperlessngx.total" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="paperlessngx.inbox" value={inboxData.count} />
+      <Block label="paperlessngx.total" value={documentData.count} />
+    </Container>
+  );
+}

--- a/src/widgets/paperlessngx/widget.js
+++ b/src/widgets/paperlessngx/widget.js
@@ -1,0 +1,25 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    "inbox": {
+      endpoint: "documents/",
+      params: ["format", "query", "fields"],
+      validate: [
+        "count"
+      ]
+    },
+    "documents": {
+      endpoint: "documents/",
+      params: ["format", "fields"],
+      validate: [
+        "count"
+      ]
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/paperlessngx/widget.js
+++ b/src/widgets/paperlessngx/widget.js
@@ -5,18 +5,10 @@ const widget = {
   proxyHandler: genericProxyHandler,
 
   mappings: {
-    "inbox": {
-      endpoint: "documents/",
-      params: ["format", "query", "fields"],
+    "statistics": {
+      endpoint: "statistics/?format=json",
       validate: [
-        "count"
-      ]
-    },
-    "documents": {
-      endpoint: "documents/",
-      params: ["format", "fields"],
-      validate: [
-        "count"
+        "documents_total"
       ]
     },
   },

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -18,6 +18,7 @@ import npm from "./npm/widget";
 import nzbget from "./nzbget/widget";
 import ombi from "./ombi/widget";
 import overseerr from "./overseerr/widget";
+import paperlessngx from "./paperlessngx/widget";
 import pihole from "./pihole/widget";
 import plex from "./plex/widget";
 import portainer from "./portainer/widget";
@@ -63,6 +64,7 @@ const widgets = {
   nzbget,
   ombi,
   overseerr,
+  paperlessngx,
   pihole,
   plex,
   portainer,


### PR DESCRIPTION
Added a widget for [paperless-ngx](https://github.com/paperless-ngx/paperless-ngx). It should also be compatible with paperless-ng (and paperless?), as i didn't see any difference in the api endpoints, that this widget is using.


Config:
```
  - Paperless-ngx:
      description: Document Management
      icon: paperless
      href: https://paperless.somedomain.com
      widget:
        type: paperlessngx
        url: https://paperless.somedomain.com
        username: user
        password: password
```

Preview:
![Unbenannt2](https://user-images.githubusercontent.com/15030658/204014394-200a0792-473b-4c45-894c-c0533a272c3c.png)

Currently the total number of documents and the number of documents in the Inbox can be displayed.
In order to get the number of documents in the inbox, the `inboxTag` must be specified in the config.

---

Now these are two metrics that i am particularly interested in. I am happy to hear your opinion/ideas (different metrics? more dynamic approach with custom queries? ...)