### PR TITLE
Fix datetime react render error

### DIFF
--- a/src/components/widgets/datetime/datetime.jsx
+++ b/src/components/widgets/datetime/datetime.jsx
@@ -15,22 +15,21 @@ const textSizes = {
 export default function DateTime({ options }) {
   const { text_size: textSize, format } = options;
   const { i18n } = useTranslation();
-  const [date, setDate] = useState(new Date());
-
+  const dateFormat = new Intl.DateTimeFormat(i18n.language, { ...format });
+  const [date, setDate] = useState("");
+  
   useEffect(() => {
     const interval = setInterval(() => {
-      setDate(new Date());
+      setDate(dateFormat.format(new Date()));
     }, 1000);
     return () => clearInterval(interval);
-  }, [setDate]);
-
-  const dateFormat = new Intl.DateTimeFormat(i18n.language, { ...format });
+  }, [date, setDate]);
 
   return (
     <div className="flex flex-col justify-center first:ml-0 ml-4">
       <div className="flex flex-row items-center grow justify-end">
         <span className={`text-theme-800 dark:text-theme-200 ${textSizes[textSize || "lg"]}`}>
-          {dateFormat.format(date)}
+          {date}
         </span>
       </div>
     </div>


### PR DESCRIPTION
This bug seems to have no real negative effect but currently the date time info widget will throw react rehydration errors e.g. `Uncaught Error: Minified React error #425; visit https://reactjs.org/docs/error-decoder.html?invariant=425 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.` due to the server vs client rendering of the date time widget. This PR corrects this. 

Functionally for users this will mean that instead of seeing a flash of the incorrect time on startup they will see a flash of nothing. Videos below demonstrate.

Current:

https://user-images.githubusercontent.com/4887959/204359201-e4569694-043f-48cf-b9d1-3b20abc1d7e2.mov

Now:

https://user-images.githubusercontent.com/4887959/204359217-478ae42c-7611-4c1b-9629-c66f4dd4d847.mov

The issue / fix can be easily reproduced / tested using the new devcontainers =)