### PR TITLE
Change: Show memory up to 1 decimal place

### DIFF
--- a/src/components/widgets/resources/memory.jsx
+++ b/src/components/widgets/resources/memory.jsx
@@ -52,7 +52,7 @@ export default function Memory({ expanded }) {
       <div className="flex flex-col ml-3 text-left min-w-[85px]">
         <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
           <div className="pl-0.5">
-            {t("common.bytes", { value: data.memory.freeMemMb * 1024 * 1024, maximumFractionDigits: 0, binary: true })}
+            {t("common.bytes", { value: data.memory.freeMemMb * 1024 * 1024, maximumFractionDigits: 1, binary: true })}
           </div>
           <div className="pr-1">{t("resources.free")}</div>
         </span>
@@ -61,7 +61,7 @@ export default function Memory({ expanded }) {
             <div className="pl-0.5">
               {t("common.bytes", {
                 value: data.memory.totalMemMb * 1024 * 1024,
-                maximumFractionDigits: 0,
+                maximumFractionDigits: 1,
                 binary: true,
               })}
             </div>


### PR DESCRIPTION
I agree with the issue #497 that memory should show a decimal, i.e. 1.7GiB instead of 2GiB, doesnt negatively affect the aesthetic of the widget imho (screenshot below). If others disagree happy to discuss ofc.

<img width="142" alt="Screen Shot 2022-11-28 at 5 36 10 PM" src="https://user-images.githubusercontent.com/4887959/204417129-a6a07520-a227-41c8-8daf-b8662fbc555d.png">

Closes #497