### PR TITLE
Added processing count to overseerr

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -155,6 +155,7 @@
     },
     "overseerr": {
         "pending": "Pending",
+        "processing": "Processing",
         "approved": "Approved",
         "available": "Available"
     },
@@ -313,7 +314,7 @@
         "child_bridges": "Child Bridges",
         "child_bridges_status": "{{ok}}/{{total}}"
     },
-    "watchtower":{
+    "watchtower": {
         "containers_scanned": "Scanned",
         "containers_updated": "Updated",
         "containers_failed": "Failed"

--- a/src/widgets/overseerr/component.jsx
+++ b/src/widgets/overseerr/component.jsx
@@ -15,6 +15,7 @@ export default function Component({ service }) {
     return (
       <Container service={service}>
         <Block label="overseerr.pending" />
+        <Block label="overseerr.processing" />
         <Block label="overseerr.approved" />
         <Block label="overseerr.available" />
       </Container>
@@ -24,6 +25,7 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="overseerr.pending" value={statsData.pending} />
+      <Block label="overseerr.processing" value={statsData.processing} />
       <Block label="overseerr.approved" value={statsData.approved} />
       <Block label="overseerr.available" value={statsData.available} />
     </Container>

--- a/src/widgets/overseerr/widget.js
+++ b/src/widgets/overseerr/widget.js
@@ -9,6 +9,7 @@ const widget = {
       endpoint: "request/count",
       validate: [
         "pending",
+        "processing",
         "approved",
         "available",
       ],


### PR DESCRIPTION
The `processing` count is a count of the still in process (Requested) media. It is equal to the `approved` minus the `available`.

 It is available in the same API call as the other information.