### PR TITLE
Change: Add fallback to http GET for ping

### DIFF
--- a/src/pages/api/ping.js
+++ b/src/pages/api/ping.js
@@ -15,11 +15,18 @@ export default async function handler(req, res) {
         });
     }
     
-    const startTime = performance.now();
-    const [status] = await httpProxy(pingURL, {
+    let startTime = performance.now();
+    let [status] = await httpProxy(pingURL, {
       method: "HEAD"
     });
-    const endTime = performance.now();
+    let endTime = performance.now();
+    
+    if (status >= 400 && status < 500) {
+      // try one more time as a GET in case HEAD is rejected for whatever reason
+      startTime = performance.now();
+      [status] = await httpProxy(pingURL);
+      endTime = performance.now();
+    }
 
     return res.status(200).json({
       status,


### PR DESCRIPTION
After much discussion in #572 it seems that its not so uncommon that services reject a `HEAD` request but do respond to a regular `GET`, this PR adds a fallback to GET for the ping feature. The 'cost' is that true failures will now require 2 calls if the response is not a 500.