### PR TITLE
Feature: Add default interval setting for coinmarketcap

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -118,6 +118,7 @@ export function cleanServiceGroups(groups) {
           container,
           currency, // coinmarketcap widget
           symbols,
+          defaultinterval
         } = cleanedService.widget;
 
         cleanedService.widget = {
@@ -129,6 +130,7 @@ export function cleanServiceGroups(groups) {
 
         if (currency) cleanedService.widget.currency = currency;
         if (symbols) cleanedService.widget.symbols = symbols;
+        if (defaultinterval) cleanedService.widget.defaultinterval = defaultinterval;
 
         if (type === "docker") {
           if (server) cleanedService.widget.server = server;

--- a/src/widgets/coinmarketcap/component.jsx
+++ b/src/widgets/coinmarketcap/component.jsx
@@ -17,11 +17,12 @@ export default function Component({ service }) {
     { label: t("coinmarketcap.30days"), value: "30d" },
   ];
 
-  const [dateRange, setDateRange] = useState(dateRangeOptions[0].value);
-
   const { widget } = service;
   const { symbols } = widget;
   const currencyCode = widget.currency ?? "USD";
+  const interval = widget.defaultinterval ?? dateRangeOptions[0].value;
+
+  const [dateRange, setDateRange] = useState(interval);
 
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "v1/cryptocurrency/quotes/latest", {
     symbol: `${symbols.join(",")}`,


### PR DESCRIPTION
This PR supersedes #597 and fixes #444 by adding an optional default interval for for CMC

```
        widget:
            type: coinmarketcap
            currency: GBP # Optional
            symbols: [BTC, LTC, ETH]
            defaultinterval: 24h
            key: xxx
```