### PR TITLE
Fix: settings not picked up after first container creation

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -99,7 +99,7 @@ function Index({ initialSettings, fallback }) {
           localStorage.setItem("hash", hashData.hash);
         }
 
-        if (previousHash && previousHash !== hashData.hash) {
+        if (!initialSettings.isValid || (previousHash && previousHash !== hashData.hash)) {
           setStale(true);
           localStorage.setItem("hash", hashData.hash);
 
@@ -111,7 +111,7 @@ function Index({ initialSettings, fallback }) {
         }
       }
     }
-  }, [hashData]);
+  }, [hashData, initialSettings]);
 
   if (stale) {
     return (

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { join } from "path";
-import { existsSync, copyFile, readFileSync } from "fs";
+import { existsSync, copyFile, readFileSync, statSync } from "fs";
 
 import yaml from "js-yaml";
 
@@ -32,5 +32,18 @@ export function getSettings() {
 
   const settingsYaml = join(process.cwd(), "config", "settings.yaml");
   const fileContents = readFileSync(settingsYaml, "utf8");
-  return yaml.load(fileContents) ?? {};
+
+  let stats;
+  try {
+    stats = statSync(settingsYaml);
+  } catch (e) {
+    stats = {};
+  }
+
+  const yamlLoaded = yaml.load(fileContents) ?? {};
+
+  return { 
+    ...yamlLoaded,
+    isValid: fileContents !== "-\n" && stats.size !== 2 // see https://github.com/benphelps/homepage/pull/609
+  };
 }


### PR DESCRIPTION
Wow, this one was a rabbit-hole...

See the linked issue, basically every time the container is re-created the settings aren't picked up until forcing revalidate (e.g. with the little refresh icon, changing the file etc).

I eventually traced this to the fact that [`getSettings()`](https://github.com/benphelps/homepage/blob/f09268230e269a8a6f679b1cfec1212a6029d28f/src/utils/config/config.js#L30) is returning nonsense for the file contents of the settings file when run at build time. It literally returns the string `-\n`. Thats true if you have a normal settings.yaml file, an empty one or the skeleton.

I have no idea if thats a bug in a dependency somewhere or what, I tried to track down why but still dont know. That said, if we can detect that we should be able to force revalidate to fix the end-user issue. I also added a check for the file size (2 bytes). Im not positive how reproducible this is on different platforms but I dont think it'll be problematic as I dont see a valid reason someone would want to have a 2 byte settings.yaml file with just `-` 😑

I know this seems a bit hack-y, if someone else has a better idea I'm all ears... its definitely a weird one.

Would love others to test, you'd have to pull this branch and then build the image, it only happens in docker.

Fixes #576