### PR TITLE
Fix: Hide docker memory stats when unsupported

### DIFF
--- a/src/widgets/docker/component.jsx
+++ b/src/widgets/docker/component.jsx
@@ -46,7 +46,9 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="docker.cpu" value={t("common.percent", { value: calculateCPUPercent(statsData.stats) })} />
-      <Block label="docker.mem" value={t("common.bytes", { value: statsData.stats.memory_stats.usage })} />
+      {statsData.stats.memory_stats.usage && 
+        <Block label="docker.mem" value={t("common.bytes", { value: statsData.stats.memory_stats.usage })} />
+      }
       {network && (
         <>
           <Block label="docker.rx" value={t("common.bytes", { value: network.rx_bytes })} />


### PR DESCRIPTION
Closes #604 
<img width="507" alt="Screen Shot 2022-12-03 at 1 42 51 AM" src="https://user-images.githubusercontent.com/4887959/205434615-1e2a6ed6-8f47-4e12-ba66-495f14ccb347.png">
