### PR TITLE
Respect scrutiny device status threshold setting

### DIFF
--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -9,7 +9,10 @@ export default function Component({ service }) {
     passed: 0,
     failed_smart: 1,
     failed_scrutiny: 2,
-    failed_both: 3
+    failed_both: 3,
+
+    isFailed: function ( s ) { return s > this.passed && s <= this.failed_both},
+    isUnknown: function ( s ) { return s < this.passed || s > this.failed_both}
   }
   
   // @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/core/config/app.config.ts
@@ -37,14 +40,14 @@ export default function Component({ service }) {
         <Block label="scrutiny.unknown" />
       </Container>
     );
-  }
+  } 
 
   const deviceIds = Object.values(scrutinyData.data.summary);
   const statusThreshold = scrutinySettings.settings.metrics.status_threshold;
-  
-  const failed = deviceIds.filter(deviceId => (deviceId.device.device_status > 0 && statusThreshold === DeviceStatusThreshold.both) || [statusThreshold, DeviceStatus.failed_both].includes(deviceId.device.device_status))?.length || 0;
-  const unknown = deviceIds.filter(deviceId => deviceId.device.device_status < DeviceStatus.passed || deviceId.device.device_status > DeviceStatus.failed_both)?.length || 0;
-  const passed = deviceIds.filter(deviceId => deviceId.device.device_status === 0 || (deviceId.device.device_status > statusThreshold && deviceId.device.device_status < DeviceStatus.failed_both))?.length || 0;
+
+  const failed = deviceIds.filter(deviceId => (DeviceStatus.isFailed(deviceId.device.device_status) && statusThreshold === DeviceStatusThreshold.both) || [statusThreshold, DeviceStatus.failed_both].includes(deviceId.device.device_status))?.length || 0;
+  const unknown = deviceIds.filter(deviceId => DeviceStatus.isUnknown(deviceId.device.device_status))?.length || 0;
+  const passed = deviceIds.length - (failed + unknown);
 
   return (
     <Container service={service}>
@@ -52,7 +55,7 @@ export default function Component({ service }) {
       <Block label="scrutiny.failed" value={failed} />
       <Block label="scrutiny.unknown" value={unknown} />
     </Container>
+    
   );
+  
 }
-
-

--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -2,26 +2,26 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+
+// @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/shared/device-status.pipe.ts
+const DeviceStatus = {
+  passed: 0,
+  failed_smart: 1,
+  failed_scrutiny: 2,
+  failed_both: 3,
+
+  isFailed(s){ return s > this.passed && s <= this.failed_both},
+  isUnknown(s){ return s < this.passed || s > this.failed_both}
+}
+
+// @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/core/config/app.config.ts
+const DeviceStatusThreshold = {
+  smart: 1,
+  scrutiny: 2,
+  both: 3
+}
+
 export default function Component({ service }) {
-
-  // @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/shared/device-status.pipe.ts
-  const DeviceStatus = {
-    passed: 0,
-    failed_smart: 1,
-    failed_scrutiny: 2,
-    failed_both: 3,
-
-    isFailed: function ( s ) { return s > this.passed && s <= this.failed_both},
-    isUnknown: function ( s ) { return s < this.passed || s > this.failed_both}
-  }
-  
-  // @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/core/config/app.config.ts
-  const DeviceStatusThreshold = {
-    smart: 1,
-    scrutiny: 2,
-    both: 3
-  }
-  
   const { widget } = service;
 
   const { data: scrutinySettings, error: scrutinySettingsError } = useWidgetAPI(widget, "settings");
@@ -59,3 +59,4 @@ export default function Component({ service }) {
   );
   
 }
+

--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -3,15 +3,39 @@ import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
-  const { widget } = service;
 
-  const { data: scrutinyData, error: scrutinyError } = useWidgetAPI(widget, "summary");
-
-  if (scrutinyError) {
-    return <Container error={scrutinyError} />;
+  // @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/shared/device-status.pipe.ts
+  const DeviceStatus = {
+    passed: 0,
+    failed_smart: 1,
+    failed_scrutiny: 2,
+    failed_both: 3
+  }
+  
+  // @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/core/config/app.config.ts
+  const DeviceStatusThreshold = {
+    smart : 1,
+    scrutiny: 2,
+    both: 3
   }
 
-  if (!scrutinyData) {
+  const thresholdStatusMapping = new Map([
+    [DeviceStatusThreshold.smart, DeviceStatus.failed_smart],
+    [DeviceStatusThreshold.scrutiny, DeviceStatus.scrutiny],
+    [DeviceStatusThreshold.both, DeviceStatusThreshold.both]
+  ])
+  
+  const { widget } = service;
+
+  const { data: scrutinySettings, error: scrutinySettingsError } = useWidgetAPI(widget, "settings");
+  const { data: scrutinyData, error: scrutinyError } = useWidgetAPI(widget, "summary");
+
+  if (scrutinyError || scrutinySettingsError) {
+    const finalError = scrutinyError ?? scrutinySettingsError;
+    return <Container error={finalError} />;
+  }
+
+  if (!scrutinyData || !scrutinySettings) {
     return (
       <Container service={service}>
         <Block label="scrutiny.passed" />
@@ -22,10 +46,11 @@ export default function Component({ service }) {
   }
 
   const deviceIds = Object.values(scrutinyData.data.summary);
+  const statusThreshold = scrutinySettings.settings.metrics.status_threshold;
   
+  const failed = deviceIds.filter(deviceId => [thresholdStatusMapping.get(statusThreshold), DeviceStatus.failed_both].includes(deviceId.device.device_status))?.length || 0;
+  const unknown = deviceIds.filter(deviceId => deviceId.device.device_status < DeviceStatus.passed || deviceId.device.device_status > DeviceStatus.failed_both)?.length || 0;
   const passed = deviceIds.filter(deviceId => deviceId.device.device_status === 0)?.length || 0;
-  const failed = deviceIds.filter(deviceId => deviceId.device.device_status > 0 && deviceId.device.device_status <= 3)?.length || 0;
-  const unknown = deviceIds.length - (passed + failed) || 0;
 
   return (
     <Container service={service}>
@@ -35,3 +60,5 @@ export default function Component({ service }) {
     </Container>
   );
 }
+
+

--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -21,8 +21,8 @@ export default function Component({ service }) {
 
   const thresholdStatusMapping = new Map([
     [DeviceStatusThreshold.smart, DeviceStatus.failed_smart],
-    [DeviceStatusThreshold.scrutiny, DeviceStatus.scrutiny],
-    [DeviceStatusThreshold.both, DeviceStatusThreshold.both]
+    [DeviceStatusThreshold.scrutiny, DeviceStatus.failed_scrutiny],
+    [DeviceStatusThreshold.both, DeviceStatus.both]
   ])
   
   const { widget } = service;

--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -14,16 +14,10 @@ export default function Component({ service }) {
   
   // @see https://github.com/AnalogJ/scrutiny/blob/d8d56f77f9e868127c4849dac74d65512db658e8/webapp/frontend/src/app/core/config/app.config.ts
   const DeviceStatusThreshold = {
-    smart : 1,
+    smart: 1,
     scrutiny: 2,
     both: 3
   }
-
-  const thresholdStatusMapping = new Map([
-    [DeviceStatusThreshold.smart, DeviceStatus.failed_smart],
-    [DeviceStatusThreshold.scrutiny, DeviceStatus.failed_scrutiny],
-    [DeviceStatusThreshold.both, DeviceStatus.both]
-  ])
   
   const { widget } = service;
 
@@ -48,9 +42,9 @@ export default function Component({ service }) {
   const deviceIds = Object.values(scrutinyData.data.summary);
   const statusThreshold = scrutinySettings.settings.metrics.status_threshold;
   
-  const failed = deviceIds.filter(deviceId => [thresholdStatusMapping.get(statusThreshold), DeviceStatus.failed_both].includes(deviceId.device.device_status))?.length || 0;
+  const failed = deviceIds.filter(deviceId => (deviceId.device.device_status > 0 && statusThreshold === DeviceStatusThreshold.both) || [statusThreshold, DeviceStatus.failed_both].includes(deviceId.device.device_status))?.length || 0;
   const unknown = deviceIds.filter(deviceId => deviceId.device.device_status < DeviceStatus.passed || deviceId.device.device_status > DeviceStatus.failed_both)?.length || 0;
-  const passed = deviceIds.filter(deviceId => deviceId.device.device_status === 0)?.length || 0;
+  const passed = deviceIds.filter(deviceId => deviceId.device.device_status === 0 || (deviceId.device.device_status > statusThreshold && deviceId.device.device_status < DeviceStatus.failed_both))?.length || 0;
 
   return (
     <Container service={service}>

--- a/src/widgets/scrutiny/widget.js
+++ b/src/widgets/scrutiny/widget.js
@@ -11,6 +11,12 @@ const widget = {
         "data",
       ]
     },
+    settings: {
+      endpoint: "settings",
+      validate: [
+        "settings",
+      ]
+    }
   },
 };
 


### PR DESCRIPTION
This PR addresses the issue mentioned [here](https://github.com/benphelps/homepage/issues/596).

The scrutiny widget now respects the device status threshold setting when calculating the number of failed and passed devices.