### PR TITLE
Correct stylized spelling of Authentik

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 - Service Integration
   - Sonarr, Radarr, Readarr, Prowlarr, Bazarr, Lidarr, Emby, Jellyfin, Tautulli (Plex)
   - Ombi, Overseerr, Jellyseerr, Jackett, NZBGet, SABnzbd, ruTorrent, Transmission, qBittorrent
-  - Portainer, Traefik, Speedtest Tracker, PiHole, AdGuard Home, Nginx Proxy Manager, Gotify, Syncthing Relay Server, Authentic, Proxmox
+  - Portainer, Traefik, Speedtest Tracker, PiHole, AdGuard Home, Nginx Proxy Manager, Gotify, Syncthing Relay Server, Authentik, Proxmox
 - Information Providers
   - Coin Market Cap, Mastodon
 - Information & Utility Widgets


### PR DESCRIPTION
The README currently has Authentik spelled as Authentic. 