### PR TITLE
Fix rate unit displays

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -98,20 +98,21 @@ module.exports = {
         );
 
         i18next.services.formatter.add("rate", (value, lng, options) => {
-          if (value === 0) return "0 Bps";
 
-          const bits = options.bits ? value : value / 8;
-          const k = 1024;
+          const k = options.binary ? 1024 : 1000;
+          const sizes = options.bits ? (options.binary ? BIBIT_UNITS : BIT_UNITS) : (options.binary ? BIBYTE_UNITS : BYTE_UNITS);
+
+          if (value === 0) return `0 ${sizes[0]}/s`;
+
           const dm = options.decimals ? options.decimals : 0;
-          const sizes = ["Bps", "KiBps", "MiBps", "GiBps", "TiBps", "PiBps", "EiBps", "ZiBps", "YiBps"];
 
-          const i = Math.floor(Math.log(bits) / Math.log(k));
+          const i = options.binary ? 2 : Math.floor(Math.log(value) / Math.log(k));
 
           const formatted = new Intl.NumberFormat(lng, { maximumFractionDigits: dm, minimumFractionDigits: dm }).format(
-            parseFloat(bits / k ** i)
+            parseFloat(value / k ** i)
           );
 
-          return `${formatted} ${sizes[i]}`;
+          return `${formatted} ${sizes[i]}/s`;
         });
 
         i18next.services.formatter.add("percent", (value, lng, options) =>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3,9 +3,11 @@
         "bytes": "{{value, bytes}}",
         "bits": "{{value, bytes(bits: true)}}",
         "bbytes": "{{value, bytes(binary: true)}}",
-        "bbits": "{{value, bytes(bits: true, binary: true)}}",
-        "byterate": "{{value, rate}}",
+        "bbits": "{{value, bytes(bits: true; binary: true)}}",
+        "byterate": "{{value, rate(bits: false)}}",
+        "bibyterate": "{{value, rate(bits: false; binary: true)}}",
         "bitrate": "{{value, rate(bits: true)}}",
+        "bibitrate": "{{value, rate(bits: true; binary: true)}}",
         "percent": "{{value, percent}}",
         "number": "{{value, number}}",
         "ms": "{{value, number}}"

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -44,9 +44,9 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="qbittorrent.leech" value={t("common.number", { value: leech })} />
-      <Block label="qbittorrent.download" value={t("common.bitrate", { value: rateDl })} />
+      <Block label="qbittorrent.download" value={t("common.bibyterate", { value: rateDl, decimals: 1 })} />
       <Block label="qbittorrent.seed" value={t("common.number", { value: completed })} />
-      <Block label="qbittorrent.upload" value={t("common.bitrate", { value: rateUl })} />
+      <Block label="qbittorrent.upload" value={t("common.bibyterate", { value: rateUl, decimals: 1 })} />
     </Container>
   );
 }

--- a/src/widgets/speedtest/component.jsx
+++ b/src/widgets/speedtest/component.jsx
@@ -29,9 +29,9 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block
         label="speedtest.download"
-        value={t("common.bitrate", { value: speedtestData.data.download * 1024 * 1024 })}
+        value={t("common.bitrate", { value: speedtestData.data.download * 1000 * 1000 })}
       />
-      <Block label="speedtest.upload" value={t("common.bitrate", { value: speedtestData.data.upload * 1024 * 1024 })} />
+      <Block label="speedtest.upload" value={t("common.bitrate", { value: speedtestData.data.upload * 1000 * 1000 })} />
       <Block
         label="speedtest.ping"
         value={t("common.ms", {


### PR DESCRIPTION
Closes #619 

I need a 🍺 after this one...

This updates speedtracker + qbittorrent, there may be other widgets using the wrong unit (wrong meaning dont match their source) but there are now options that should cover them if anyone notices, and hopefully are correct e.g.
```
        "byterate": "{{value, rate(bits: false)}}",
        "bibyterate": "{{value, rate(bits: false; binary: true)}}",
        "bitrate": "{{value, rate(bits: true)}}",
        ...
```