### PR TITLE
Fix: allow multiple instances of certain widgets

### DIFF
--- a/src/widgets/pyload/proxy.js
+++ b/src/widgets/pyload/proxy.js
@@ -11,7 +11,7 @@ const logger = createLogger(proxyName);
 const sessionCacheKey = `${proxyName}__sessionId`;
 const isNgCacheKey = `${proxyName}__isNg`;
 
-async function fetchFromPyloadAPI(url, sessionId, params) {
+async function fetchFromPyloadAPI(url, sessionId, params, service) {
   const options = {
     body: params
       ? Object.keys(params)
@@ -25,10 +25,10 @@ async function fetchFromPyloadAPI(url, sessionId, params) {
   };
 
   // see https://github.com/benphelps/homepage/issues/517
-  const isNg = cache.get(isNgCacheKey);
+  const isNg = cache.get(`${isNgCacheKey}.${service}`);
   if (isNg && !params) {
     delete options.body;
-    options.headers.Cookie = cache.get(sessionCacheKey);
+    options.headers.Cookie = cache.get(`${sessionCacheKey}.${service}`);
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -43,19 +43,19 @@ async function fetchFromPyloadAPI(url, sessionId, params) {
   return [status, returnData, responseHeaders];
 }
 
-async function login(loginUrl, username, password = '') {
-  const [status, sessionId, responseHeaders] = await fetchFromPyloadAPI(loginUrl, null, { username, password });
+async function login(loginUrl, service, username, password = '') {
+  const [status, sessionId, responseHeaders] = await fetchFromPyloadAPI(loginUrl, null, { username, password }, service);
   
   // this API actually returns status 200 even on login failure
   if (status !== 200 || sessionId === false) {
     logger.error(`HTTP ${status} logging into Pyload API, returned: ${JSON.stringify(sessionId)}`);
   } else if (responseHeaders['set-cookie']?.join().includes('pyload_session')) {
     // Support pyload-ng, see https://github.com/benphelps/homepage/issues/517
-    cache.put(isNgCacheKey, true);
+    cache.put(`${isNgCacheKey}.${service}`, true);
     const sessionCookie = responseHeaders['set-cookie'][0];
-    cache.put(sessionCacheKey, sessionCookie, 60 * 60 * 23 * 1000); // cache for 23h
+    cache.put(`${sessionCacheKey}.${service}`, sessionCookie, 60 * 60 * 23 * 1000); // cache for 23h
   } else {
-    cache.put(sessionCacheKey, sessionId);
+    cache.put(`${sessionCacheKey}.${service}`, sessionId);
   }
 
   return sessionId;
@@ -72,14 +72,14 @@ export default async function pyloadProxyHandler(req, res) {
         const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
         const loginUrl = `${widget.url}/api/login`;
 
-        let sessionId = cache.get(sessionCacheKey) ?? await login(loginUrl, widget.username, widget.password);
-        let [status, data] = await fetchFromPyloadAPI(url, sessionId);
+        let sessionId = cache.get(`${sessionCacheKey}.${service}`) ?? await login(loginUrl, service, widget.username, widget.password);
+        let [status, data] = await fetchFromPyloadAPI(url, sessionId, null, service);
 
         if (status === 403 || status === 401) {
           logger.info('Failed to retrieve data from Pyload API, trying to login again...');
-          cache.del(sessionCacheKey);
-          sessionId = await login(loginUrl, widget.username, widget.password);
-          [status, data] = await fetchFromPyloadAPI(url, sessionId);
+          cache.del(`${sessionCacheKey}.${service}`);
+          sessionId = await login(loginUrl, service, widget.username, widget.password);
+          [status, data] = await fetchFromPyloadAPI(url, sessionId, null, service);
         }
 
         if (data?.error || status !== 200) {

--- a/src/widgets/transmission/proxy.js
+++ b/src/widgets/transmission/proxy.js
@@ -25,12 +25,12 @@ export default async function transmissionProxyHandler(req, res) {
     return res.status(400).json({ error: "Invalid proxy service type" });
   }
 
-  let headers = cache.get(headerCacheKey);
+  let headers = cache.get(`${headerCacheKey}.${service}`);
   if (!headers) {
     headers = {
       "content-type": "application/json",
     }
-    cache.put(headerCacheKey, headers);
+    cache.put(`${headerCacheKey}.${service}`, headers);
   }
 
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
@@ -55,7 +55,7 @@ export default async function transmissionProxyHandler(req, res) {
   if (status === 409) {
     logger.debug("Transmission is rejecting the request, but returning a CSRF token");
     headers[csrfHeaderName] = responseHeaders[csrfHeaderName];
-    cache.put(headerCacheKey, headers);
+    cache.put(`${headerCacheKey}.${service}`, headers);
 
     // retry the request, now with the CSRF token
     [status, contentType, data, responseHeaders] = await httpProxy(url, {

--- a/src/widgets/unifi/proxy.js
+++ b/src/widgets/unifi/proxy.js
@@ -58,6 +58,7 @@ async function login(widget) {
 
 export default async function unifiProxyHandler(req, res) {
   const widget = await getWidget(req);
+  const { service } = req.query;
   if (!widget) {
     return res.status(400).json({ error: "Invalid proxy service type" });
   }
@@ -68,7 +69,7 @@ export default async function unifiProxyHandler(req, res) {
   }
 
   let [status, contentType, data, responseHeaders] = [];
-  let prefix = cache.get(prefixCacheKey);
+  let prefix = cache.get(`${prefixCacheKey}.${service}`);
   if (prefix === null) {
     // auto detect if we're talking to a UDM Pro, and cache the result so that we
     // don't make two requests each time data from Unifi is required
@@ -77,7 +78,7 @@ export default async function unifiProxyHandler(req, res) {
     if (responseHeaders?.["x-csrf-token"]) {
       prefix = udmpPrefix;
     }
-    cache.put(prefixCacheKey, prefix);
+    cache.put(`${prefixCacheKey}.${service}`, prefix);
   }
 
   widget.prefix = prefix;


### PR DESCRIPTION
Closes #649

This allows for duplicates of certain widgets (the ones that cache a key or token or whatever) by appending the service name to the cache key. This still requires that the service name be unique, but that's already the case.

I did make sure I didnt break them all =)

<img width="518" alt="Screen Shot 2022-12-09 at 9 19 11 PM" src="https://user-images.githubusercontent.com/4887959/206831774-17447528-40a3-444e-bf02-46e705683944.png">
<img width="527" alt="Screen Shot 2022-12-09 at 9 37 11 PM" src="https://user-images.githubusercontent.com/4887959/206831777-7fe3855a-2808-48cc-9154-aabf367eff60.png">
<img width="539" alt="Screen Shot 2022-12-09 at 9 37 17 PM" src="https://user-images.githubusercontent.com/4887959/206831780-70a05dc1-bcac-4073-9f6b-4c0a20a6a87e.png">
<img width="546" alt="Screen Shot 2022-12-09 at 9 39 20 PM" src="https://user-images.githubusercontent.com/4887959/206831789-d89c692a-0396-4a60-af9c-612b37ee9110.png">
<img width="529" alt="Screen Shot 2022-12-09 at 9 50 28 PM" src="https://user-images.githubusercontent.com/4887959/206831790-1984435f-87f2-40a8-b6fc-ab6f43d2afe6.png">
<img width="507" alt="Screen Shot 2022-12-09 at 9 46 42 PM" src="https://user-images.githubusercontent.com/4887959/206831794-703a83f0-7dd7-4990-9267-2d4e7f026392.png">
