### PR TITLE
Pihole allow auth, updated API endpoint

### DIFF
--- a/src/widgets/pihole/component.jsx
+++ b/src/widgets/pihole/component.jsx
@@ -9,7 +9,7 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  const { data: piholeData, error: piholeError } = useWidgetAPI(widget, "api.php");
+  const { data: piholeData, error: piholeError } = useWidgetAPI(widget, "summaryRaw");
 
   if (piholeError) {
     return <Container error={piholeError} />;
@@ -27,9 +27,9 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="pihole.queries" value={t("common.number", { value: piholeData.dns_queries_today })} />
-      <Block label="pihole.blocked" value={t("common.number", { value: piholeData.ads_blocked_today })} />
-      <Block label="pihole.gravity" value={t("common.number", { value: piholeData.domains_being_blocked })} />
+      <Block label="pihole.queries" value={t("common.number", { value: parseInt(piholeData.dns_queries_today, 10) })} />
+      <Block label="pihole.blocked" value={t("common.number", { value: parseInt(piholeData.ads_blocked_today, 10) })} />
+      <Block label="pihole.gravity" value={t("common.number", { value: parseInt(piholeData.domains_being_blocked, 10) })} />
     </Container>
   );
 }

--- a/src/widgets/pihole/widget.js
+++ b/src/widgets/pihole/widget.js
@@ -1,12 +1,12 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  api: "{url}/admin/{endpoint}",
+  api: "{url}/admin/api.php?{endpoint}&auth={key}",
   proxyHandler: genericProxyHandler,
 
   mappings: {
-    "api.php": {
-      endpoint: "api.php",
+    "summaryRaw": {
+      endpoint: "summaryRaw",
       validate: [
         "dns_queries_today",
         "ads_blocked_today",


### PR DESCRIPTION
As helpfully pointed out in #711 pihole added an auth requirement to its api endpoints in a recent version. This adds support for that (`key` just like other widgets) and also updates the API endpoints to be more explicit. I tested this going back a few versions to ensure backwards-compatability and didnt see any issues, I think the API has been stable for quite a while.

Closes #711 

New config e.g. 

```yaml
        widget:
          type: pihole
          url: http://iporhost
          key: mypiholeapikey
```