### PR TITLE
Fix: Handle docker server failures if others succeed

### DIFF
--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -52,7 +52,7 @@ export async function servicesResponse() {
     discoveredServices = cleanServiceGroups(await servicesFromDocker());
   } catch (e) {
     console.error("Failed to discover services, please check docker.yaml for errors or remove example entries.");
-    if (e) console.error(e);
+    if (e) console.error(e.toString());
     discoveredServices = [];
   }
 
@@ -60,7 +60,7 @@ export async function servicesResponse() {
     configuredServices = cleanServiceGroups(await servicesFromConfig());
   } catch (e) {
     console.error("Failed to load services.yaml, please check for errors");
-    if (e) console.error(e);
+    if (e) console.error(e.toString());
     configuredServices = [];
   }
 
@@ -68,7 +68,7 @@ export async function servicesResponse() {
     initialSettings = await getSettings();
   } catch (e) {
     console.error("Failed to load settings.yaml, please check for errors");
-    if (e) console.error(e);
+    if (e) console.error(e.toString());
     initialSettings = {};
   }
 


### PR DESCRIPTION
This PR updates the api-response for docker servers to fix the linked issue, basically when one server fails an error was thrown that halts all discovery.

To test, just add a non-functional entry to docker.yaml =)

Closes #710