### PR TITLE
Fix: version check caching

### DIFF
--- a/src/components/version.jsx
+++ b/src/components/version.jsx
@@ -3,8 +3,6 @@ import useSWR from "swr";
 import { compareVersions } from "compare-versions";
 import { MdNewReleases } from "react-icons/md";
 
-import cachedFetch from "utils/proxy/cached-fetch";
-
 export default function Version() {
   const { t, i18n } = useTranslation();
 
@@ -12,9 +10,7 @@ export default function Version() {
   const revision = process.env.NEXT_PUBLIC_REVISION?.length ? process.env.NEXT_PUBLIC_REVISION : "dev";
   const version = process.env.NEXT_PUBLIC_VERSION?.length ?  process.env.NEXT_PUBLIC_VERSION : "dev";
 
-  const cachedFetcher = (resource) => cachedFetch(resource, 5);
-
-  const { data: releaseData } = useSWR("https://api.github.com/repos/benphelps/homepage/releases", cachedFetcher);
+  const { data: releaseData } = useSWR("/api/releases");
 
   // use Intl.DateTimeFormat to format the date
   const formatDate = (date) => {

--- a/src/pages/api/releases.js
+++ b/src/pages/api/releases.js
@@ -1,0 +1,6 @@
+import cachedFetch from "utils/proxy/cached-fetch";
+
+export default async function handler(req, res) {
+  const releasesURL = "https://api.github.com/repos/benphelps/homepage/releases";
+  return res.send(await cachedFetch(releasesURL, 5));
+}


### PR DESCRIPTION
Now that version checking was fixed =) its become apparent that the current implementation of caching of the GH releases API data used for version checking doesnt actually cache the data because its in browser memory not server-side. This fixes that.

The fact that homepage breaks when the call fails is fixed separately already but this will likely prevent that anyway.

See #738 #744 