### PR TITLE
Use tabular nums for datetime to prevent size changing

### DIFF
--- a/src/components/widgets/datetime/datetime.jsx
+++ b/src/components/widgets/datetime/datetime.jsx
@@ -28,7 +28,7 @@ export default function DateTime({ options }) {
   return (
     <div className="flex flex-col justify-center first:ml-0 ml-4">
       <div className="flex flex-row items-center grow justify-end">
-        <span className={`text-theme-800 dark:text-theme-200 ${textSizes[textSize || "lg"]}`}>
+        <span className={`text-theme-800 dark:text-theme-200 tabular-nums ${textSizes[textSize || "lg"]}`}>
           {date}
         </span>
       </div>


### PR DESCRIPTION
Uses `font-variant-numeric: tabular-nums` to prevent width changes as datetime widget seconds tick

Enjoy this relaxing video where nothing moves 🤓:

https://user-images.githubusercontent.com/4887959/210258119-d29c055a-7f3c-423e-8ced-c0bc507471c5.mov

Closes #764 