### PR TITLE
Giving Read Only rights to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ services:
       - 3000:3000
     volumes:
       - /path/to/config:/app/config # Make sure your local config directory exists
-      - /var/run/docker.sock:/var/run/docker.sock # (optional) For docker integrations
+      - /var/run/docker.sock:/var/run/docker.sock:ro # (optional) For docker integrations
 ```
 
 or docker run:


### PR DESCRIPTION
Giving Read Only rights to homepage container in docker-compose example.
Adding :RO to the docker.sock volume. When the container gets compromised the intruder will have root access basically. The container doesn't need the write privileges.

This measure will stop inexperienced people from exposing their docker.socket to the public internet.