### PR TITLE
Feature: allow setting locale for datetime widget directly

### DIFF
--- a/src/components/widgets/datetime/datetime.jsx
+++ b/src/components/widgets/datetime/datetime.jsx
@@ -13,17 +13,18 @@ const textSizes = {
 };
 
 export default function DateTime({ options }) {
-  const { text_size: textSize, format } = options;
+  const { text_size: textSize, locale, format } = options;
   const { i18n } = useTranslation();
   const [date, setDate] = useState("");
+  const dateLocale = locale ?? i18n.language;
   
   useEffect(() => {
-    const dateFormat = new Intl.DateTimeFormat(i18n.language, { ...format });
+    const dateFormat = new Intl.DateTimeFormat(dateLocale, { ...format });
     const interval = setInterval(() => {
       setDate(dateFormat.format(new Date()));
     }, 1000);
     return () => clearInterval(interval);
-  }, [date, setDate, i18n.language, format]);
+  }, [date, setDate, dateLocale, format]);
 
   return (
     <div className="flex flex-col justify-center first:ml-0 ml-4">


### PR DESCRIPTION
E.g.:
<img width="667" alt="Screen Shot 2023-01-04 at 1 50 31 PM" src="https://user-images.githubusercontent.com/4887959/210657108-339ee284-ba80-450f-8a01-53fb41694051.png">

<img width="684" alt="Screen Shot 2023-01-04 at 1 51 45 PM" src="https://user-images.githubusercontent.com/4887959/210657116-bcb8d164-5ed7-4fe6-914f-3f9c8dcff6c6.png">

<img width="617" alt="Screen Shot 2023-01-04 at 1 51 26 PM" src="https://user-images.githubusercontent.com/4887959/210657129-d8bd68df-0bef-42e3-a5a0-245e14b99de5.png">

Fixes #751