### PR TITLE
Add support for multiple instances

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -37,11 +37,11 @@ export async function servicesFromDocker() {
   const dockerYaml = path.join(process.cwd(), "config", "docker.yaml");
   const dockerFileContents = await fs.readFile(dockerYaml, "utf8");
   const servers = yaml.load(dockerFileContents);
-
+  
   if (!servers) {
     return [];
   }
-
+  const instance = servers.instance || process.env.INSTANCE;
   const serviceServers = await Promise.all(
     Object.keys(servers).map(async (serverName) => {
       try {
@@ -60,14 +60,14 @@ export async function servicesFromDocker() {
           let constructedService = null;
 
           Object.keys(container.Labels).forEach((label) => {
-            if (label.startsWith(`${process.env.INSTANCE}-homepage.`) || label.startsWith('homepage.')) {
+            if (label.startsWith(`homepage.${instance}`) || label.startsWith('homepage.')) {
               if (!constructedService) {
                 constructedService = {
                   container: container.Names[0].replace(/^\//, ""),
                   server: serverName,
                 };
               }
-              shvl.set(constructedService, label.replace(RegExp(`(${process.env.INSTANCE}-)?homepage\\.`), ""), container.Labels[label]);
+              shvl.set(constructedService, label.replace(RegExp(`homepage\\.(${instance}\\.)?`), ""), container.Labels[label]);
             }
           });
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -60,14 +60,14 @@ export async function servicesFromDocker() {
           let constructedService = null;
 
           Object.keys(container.Labels).forEach((label) => {
-            if (label.startsWith("homepage.")) {
+            if (label.startsWith(`${process.env.INSTANCE}-homepage.`) || label.startsWith('homepage.')) {
               if (!constructedService) {
                 constructedService = {
                   container: container.Names[0].replace(/^\//, ""),
                   server: serverName,
                 };
               }
-              shvl.set(constructedService, label.replace("homepage.", ""), container.Labels[label]);
+              shvl.set(constructedService, label.replace(RegExp(`(${process.env.INSTANCE}-)?homepage\\.`), ""), container.Labels[label]);
             }
           });
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -60,7 +60,7 @@ export async function servicesFromDocker() {
           let constructedService = null;
 
           Object.keys(container.Labels).forEach((label) => {
-            if (label.startsWith(`homepage.${instance}`) || label.startsWith('homepage.')) {
+            if (label.startsWith('homepage.')) {
               if (!constructedService) {
                 constructedService = {
                   container: container.Names[0].replace(/^\//, ""),


### PR DESCRIPTION
- An instance name can be set using the `INSTANCE` environment variable. 
- Instance-specific labels should have the instance name prefixed (e.g. `public-homepage.name`)
- labels without an instance name (e.g. `homepage.name`) are global
- This should somewhat address #774 