### PR TITLE
Change zn-CN translate

### DIFF
--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -296,8 +296,8 @@
         "indexers": "Indexers"
     },
     "watchtower": {
-        "containers_scanned": "以扫描",
-        "containers_updated": "以升级",
+        "containers_scanned": "已扫描",
+        "containers_updated": "已升级",
         "containers_failed": "失败"
     },
     "tubearchivist": {


### PR DESCRIPTION
Correct from '以' to '已'
meaning: 
已 -> `already`
以 -> `for`