### PR TITLE
Added support for custom themes

### DIFF
--- a/public/custom-colors.css
+++ b/public/custom-colors.css
@@ -1,0 +1,14 @@
+* {
+    --custom-color-50: ;
+    --custom-color-100: ;
+    --custom-color-200: ;
+    --custom-color-300: ;
+    --custom-color-400: ;
+    --custom-color-500: ;
+    --custom-color-600: ;
+    --custom-color-700: ;
+    --custom-color-800: ;
+    --custom-color-900: ;
+    --custom-color-logo-start: ;
+    --custom-color-logo-stop: ;
+}

--- a/src/components/toggles/color.jsx
+++ b/src/components/toggles/color.jsx
@@ -27,7 +27,7 @@ const colors = [
   "pink",
   "rose",
   "red",
-  "white",
+  "custom",
 ];
 
 export default function ColorToggle() {

--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -11,6 +11,7 @@ export default function Document() {
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <link rel="manifest" href="/site.webmanifest?v=4" />
         <link rel="mask-icon" href="/safari-pinned-tab.svg?v=4" color="#1e9cd7" />
+        <link rel="stylesheet" href="/custom-colors.css" />
       </Head>
       <body>
         <Main />

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,17 +1,17 @@
-.theme-white {
-  --color-50: 255 255 255;
-  --color-100: 255 255 255;
-  --color-200: 255 255 255;
-  --color-300: 255 255 255;
-  --color-400: 255 255 255;
-  --color-500: 60 60 60;
-  --color-600: 255 255 255;
-  --color-700: 40 40 40;
-  --color-800: 255 255 255;
-  --color-900: 255 255 255;
+.theme-custom {
+  --color-50: var(--custom-color-50, 255 255 255);
+  --color-100: var(--custom-color-100, 255 255 255);
+  --color-200: var(--custom-color-200, 255 255 255);
+  --color-300: var(--custom-color-300, 255 255 255);
+  --color-400: var(--custom-color-400, 255 255 255);
+  --color-500: var(--custom-color-500, 60 60 60);
+  --color-600: var(--custom-color-600, 255 255 255);
+  --color-700: var(--custom-color-700, 40 40 40);
+  --color-800: var(--custom-color-800, 255 255 255);
+  --color-900: var(--custom-color-900, 255 255 255);
 
-  --color-logo-start: 128 128 128 / 20%;
-  --color-logo-stop: 128 128 128 / 40%;
+  --color-logo-start: var(--custom-color-logo-start, 128 128 128 / 20%);
+  --color-logo-stop: var(--custom-color-logo-stop, 128 128 128 / 40%);
 }
 
 .theme-slate {


### PR DESCRIPTION
I renamed the `theme-white` to `theme-custom` and used the original `theme-white` colors as fallback values. 

To set a custom theme, create `public/custom-colors.css` and put something like this in it (adjusting colors as needed)

```css
* {
    --custom-color-50: 220 224 232;
    --custom-color-100: 230 233 239;
    --custom-color-200: 205 214 244;
    --custom-color-300: 124 127 147;
    --custom-color-400: 140 143 161;
    --custom-color-500: 92 95 119;
    --custom-color-600: 88 91 112;
    --custom-color-700: 76 78 105;
    --custom-color-800: 30 30 46;
    --custom-color-900: 65 69 85;
    --custom-color-logo-start: 255 0 0;
    --custom-color-logo-stop: 0 0 255;
}
```