### PR TITLE
use abbr as icon fallback

### DIFF
--- a/src/components/bookmarks/item.jsx
+++ b/src/components/bookmarks/item.jsx
@@ -19,7 +19,7 @@ export default function Item({ bookmark }) {
           <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md">
             {bookmark.icon && 
               <div className="flex-shrink-0 w-5 h-5">
-                <ResolvedIcon icon={bookmark.icon} />
+                <ResolvedIcon icon={bookmark.icon} alt={bookmark.abbr} />
               </div>
             }
             {!bookmark.icon && bookmark.abbr}

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -1,9 +1,9 @@
 import Image from "next/future/image";
 
-export default function ResolvedIcon({ icon, width = 32, height = 32 }) {
+export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "logo" }) {
   // direct or relative URLs
   if (icon.startsWith("http") || icon.startsWith("/")) {
-    return <Image src={`${icon}`} width={width} height={height} alt="logo" />;
+    return <Image src={`${icon}`} width={width} height={height} alt={alt} />;
   }
 
   // mdi- prefixed, material design icons
@@ -31,7 +31,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32 }) {
       src={`https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/${iconName}.png`}
       width={width}
       height={height}
-      alt="logo"
+      alt={alt}
     />
   );
 }


### PR DESCRIPTION
Hello, I submitted a [feature request](https://github.com/benphelps/homepage/issues/814) and was able to implement it myself. This uses the abbr property of bookmarks as a fallback in case it doesn't find the icon by replacing the "logo" string in the image's alt text. It's a tiny change, but I think it's a good one since previously abbr would just be ignored if the icon failed to load.

Here's a screenshot:
![Screenshot from 2023-01-13 22-44-05](https://user-images.githubusercontent.com/12801876/212425944-845b3dc1-1e55-4e11-89ba-ce8dc4c1ea0c.png)

Using the following bookmarks.yaml:
```
---
# For configuration options and examples, please see:
# https://gethomepage.dev/en/configs/bookmarks

- Dashboard icon:
    - Icon with abbr:
        - icon: github-light.png
          abbr: GH
          href: https://github.com/
    - Icon without abbr:
        - icon: github-light.png
          href: https://github.com/
    - Bad icon with abbr:
        - icon: github-light1.png
          abbr: GH
          href: https://github.com/
    - Bad icon without abbr:
        - icon: github-light1.png
          href: https://github.com/

- Direct or Relative URL:
    - Icon with abbr:
        - icon: /favicon-32x32.png
          abbr: RE
          href: https://github.com/
    - Icon without abbr:
        - icon: /favicon-32x32.png
          href: https://github.com
    - Bad icon with abbr:
        - icon: /notanimage.png
          abbr: RE
          href: https://github.com/
    - Bad icon without abbr:
        - icon: /notanimage.png
          href: https://github.com/

- MDI Icon:
    - Icon with abbr:
        - icon: mdi-calendar-badge.svg
          abbr: GH
          href: https://github.com/
    - Icon without abbr:
        - icon: mdi-calendar-badge.svg
          href: https://github.com/
    - Bad icon with abbr:
        - icon: mdi-doesntexist.svg
          abbr: GH
          href: https://github.com/
    - Bad icon without abbr:
        - icon: mdi-doesntexist.svg
          href: https://github.com/

- No icon:
    - With abbr:
        - abbr: GH
          href: https://github.com
    - Without abbr:
        - href: https://github.com
```