### PR TITLE
Add Medusa widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -255,6 +255,11 @@
         "status_count": "Posts",
         "domain_count": "Domains"
     },
+    "medusa": {
+        "wanted": "Wanted",
+        "queued": "Queued",
+        "series": "Series"
+    },
     "miniflux": {
         "read": "Read",
         "unread": "Unread"

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -21,6 +21,7 @@ const components = {
   jellyseerr: dynamic(() => import("./jellyseerr/component")),
   lidarr: dynamic(() => import("./lidarr/component")),
   mastodon: dynamic(() => import("./mastodon/component")),
+  medusa: dynamic(() => import("./medusa/component")),
   miniflux: dynamic(() => import("./miniflux/component")),
   mikrotik: dynamic(() => import("./mikrotik/component")),
   navidrome: dynamic(() => import("./navidrome/component")),

--- a/src/widgets/medusa/component.jsx
+++ b/src/widgets/medusa/component.jsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");
+  const { data: futureData, error: futureError } = useWidgetAPI(widget, "future");
+
+  if (statsError || futureError) {
+    const finalError = statsError ?? futureError;
+    return <Container error={finalError} />;
+  }
+
+  if (!statsData || !futureData) {
+    return (
+      <Container service={service}>
+        <Block label="medusa.wanted" />
+        <Block label="medusa.queued" />
+        <Block label="medusa.series" />
+      </Container>
+    );
+  }
+
+  const { later, missed, soon, today } = futureData.data;
+  const future = later.length + missed.length + soon.length + today.length;
+
+  return (
+    <Container service={service}>
+      <Block label="medusa.wanted" value={t("common.number", { value: future })} />
+      <Block label="medusa.queued" value={t("common.number", { value: statsData.data.ep_snatched })} />
+      <Block label="medusa.series" value={t("common.number", { value: statsData.data.shows_active })} />
+    </Container>
+  );
+}

--- a/src/widgets/medusa/widget.js
+++ b/src/widgets/medusa/widget.js
@@ -1,0 +1,23 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/v1/{key}/{endpoint}/",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    stats: {
+      endpoint: "?cmd=shows.stats",
+      validate: [
+        "data"
+      ]
+    },
+    future: {
+      endpoint: "?cmd=future",
+      validate: [
+        "data"
+      ]
+    }
+  }
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -16,6 +16,7 @@ import jackett from "./jackett/widget";
 import jellyseerr from "./jellyseerr/widget";
 import lidarr from "./lidarr/widget";
 import mastodon from "./mastodon/widget";
+import medusa from "./medusa/widget";
 import miniflux from "./miniflux/widget";
 import mikrotik from "./mikrotik/widget";
 import navidrome from "./navidrome/widget";
@@ -73,6 +74,7 @@ const widgets = {
   jellyseerr,
   lidarr,
   mastodon,
+  medusa,
   miniflux,
   mikrotik,
   navidrome,


### PR DESCRIPTION
This PR add medusa widget.

![image](https://user-images.githubusercontent.com/765858/212775961-bff16268-4329-4e44-bbbd-b15951c1a3ac.png)

It is used with :
```yaml
- Medusa:
      icon: medusa.png
      href: http://medusa.host.or.ip
      widget:
          type: medusa
          fields: ["wanted", "queued", "series"]
          url: http://medusa.host.or.ip
          key: apikeyapikeyapikeyapikeyapikey
```

Here are some api payload for each endpoint that are used:
#### `shows.stats`
```json
{
    "data": {
        "ep_downloaded": 492,
        "ep_snatched": 0,
        "ep_total": 508,
        "shows_active": 11,
        "shows_total": 27
    },
    "message": "",
    "result": "success"
}
```
#### `future`
```json
{
    "data": {
        "later": [],
        "missed": [],
        "soon": [
            {
                "airdate": "2023-01-22",
                "airs": "Sunday 9:00 PM",
                "ep_name": "The Abyss",
                "ep_plot": "",
                "episode": 6,
                "indexerid": 360295,
                "network": "BBC One",
                "paused": 0,
                "quality": "HD",
                "season": 3,
                "show_name": "His Dark Materials",
                "show_status": "Continuing",
                "tvdbid": 360295,
                "weekday": 6
            }
        ],
        "today": []
    },
    "message": "",
    "result": "success"
}
```