### PR TITLE
Fix: Handle opnsense no wan interface

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -214,7 +214,8 @@ export function cleanServiceGroups(groups) {
           defaultinterval,
           namespace, // kubernetes widget
           app,
-          podSelector
+          podSelector,
+          wan // opnsense widget
         } = cleanedService.widget;
 
         cleanedService.widget = {
@@ -236,6 +237,9 @@ export function cleanServiceGroups(groups) {
           if (namespace) cleanedService.widget.namespace = namespace;
           if (app) cleanedService.widget.app = app;
           if (podSelector) cleanedService.widget.podSelector = podSelector;
+        }
+        if (type === "opnsense") {
+          if (wan) cleanedService.widget.wan = wan;
         }
       }
 

--- a/src/widgets/opnsense/component.jsx
+++ b/src/widgets/opnsense/component.jsx
@@ -33,16 +33,14 @@ export default function Component({ service }) {
   const cpu = 100 - parseFloat(cpuIdle);
   const memory = activityData.headers[3].match(/Mem: (.+) Active,/)[1];
 
-  const wanUpload = interfaceData.interfaces.wan['bytes transmitted'];
-  const wanDownload = interfaceData.interfaces.wan['bytes received'];
+  const wan = widget.wan ? interfaceData.interfaces[widget.wan] : interfaceData.interfaces.wan;
 
   return (
     <Container service={service}>
       <Block label="opnsense.cpu" value={t("common.percent", { value: cpu.toFixed(2) })}  />
       <Block label="opnsense.memory" value={memory} />
-      <Block label="opnsense.wanUpload" value={t("common.bytes", { value: wanUpload })} />
-      <Block label="opnsense.wanDownload" value={t("common.bytes", { value: wanDownload })} />
-
+      {wan && <Block label="opnsense.wanUpload" value={t("common.bytes", { value: wan['bytes transmitted'] })} />}
+      {wan && <Block label="opnsense.wanDownload" value={t("common.bytes", { value: wan['bytes received'] })} />}
     </Container>
   );
 }


### PR DESCRIPTION
Closes #823

Im not sure how widespread the issue is here ie if the user in the linked issue's setup is highly atypical (not really familiar with opnsense) ~~but the fix is simple enough, if no `wan` fall back to `opt1`, if that doesnt exist we still prevent erroring out~~.

Edit: after re-considering, we'll allow specifying this with `wan` (optional, of course)

```yaml
          widget:
               type: opnsense
               url: http://host
               username: ...
               password: ...
               wan: opt1
```

sample data
```json
{"interfaces":{"opt1":{"flags":"8843","promiscuous listeners":"0","send queue length":"0","send queue max length":"50","send queue drops":"11405","type":"Ethernet","address length":"6","header length":"14","link state":"2","vhid":"0","datalen":"152","mtu":"1500","metric":"0","line rate":"1000000000 bit\/s","packets received":"1231016259","input errors":"0","packets transmitted":"974383218","output errors":"0","collisions":"0","bytes received":"1297921522537","bytes transmitted":"994602134170","multicasts received":"16018415","multicasts transmitted":"310","input queue drops":"0","packets for unknown protocol":"0","HW offload capabilities":"0x0","uptime at attach or stat reset":"1","name":"COAX"},"lan":{"flags":"8863","promiscuous listeners":"0","send queue length":"0","send queue max length":"50","send queue drops":"0","type":"Ethernet","address length":"6","header length":"18","link state":"2","vhid":"0","datalen":"152","mtu":"1500","metric":"0","line rate":"10000000000 bit\/s","packets received":"980736526","input errors":"0","packets transmitted":"1210947993","output errors":"0","collisions":"0","bytes received":"994637714296","bytes transmitted":"1295580754362","multicasts received":"10580964","multicasts transmitted":"0","input queue drops":"0","packets for unknown protocol":"0","HW offload capabilities":"0x0","uptime at attach or stat reset":"1","name":"LAN"},"opt2":{"flags":"8043","promiscuous listeners":"0","send queue length":"0","send queue max length":"50","send queue drops":"1","type":"PPP","address length":"0","header length":"0","link state":"2","vhid":"0","datalen":"152","mtu":"1420","metric":"0","line rate":"0 bit\/s","packets received":"1109314","input errors":"0","packets transmitted":"1566236","output errors":"0","collisions":"0","bytes received":"111421363","bytes transmitted":"1779167545","multicasts received":"0","multicasts transmitted":"0","input queue drops":"0","packets for unknown protocol":"0","HW offload capabilities":"0x0","uptime at attach or stat reset":"79","name":"VPN"},"opt3":{"flags":"8043","promiscuous listeners":"0","send queue length":"0","send queue max length":"50","send queue drops":"0","type":"PPP","address length":"0","header length":"0","link state":"2","vhid":"0","datalen":"152","mtu":"1420","metric":"0","line rate":"0 bit\/s","packets received":"0","input errors":"0","packets transmitted":"0","output errors":"0","collisions":"0","bytes received":"0","bytes transmitted":"0","multicasts received":"0","multicasts transmitted":"0","input queue drops":"0","packets for unknown protocol":"0","HW offload capabilities":"0x0","uptime at attach or stat reset":"79","name":"VPN_SERVER"}},"time":1674402854.029806}
```

<img width="380" alt="Screen Shot 2023-01-22 at 9 09 25 AM" src="https://user-images.githubusercontent.com/4887959/213929601-366686d2-9548-48cd-9925-be935cd38bf3.png">
<img width="388" alt="Screen Shot 2023-01-22 at 9 08 49 AM" src="https://user-images.githubusercontent.com/4887959/213929604-67189090-36b3-4a50-9e80-cfa2f0157f35.png">
