### PR TITLE
Cloudflared Widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -430,7 +430,7 @@
         "temp_bed": "Bed temp",
         "job_completion": "Completion"
     },
-    "cloudflared" {
+    "cloudflared": {
         "origin_ip": "Origin IP",
         "status": "Status" 
     }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -429,5 +429,9 @@
         "temp_tool": "Tool temp",
         "temp_bed": "Bed temp",
         "job_completion": "Completion"
+    },
+    "cloudflared" {
+        "origin_ip": "Origin IP",
+        "status": "Status" 
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -40,6 +40,9 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `Token ${widget.key}`;
       } else if (widget.type === "miniflux") {
         headers["X-Auth-Token"] = `${widget.key}`;
+      } else if (widget.type === "cloudflared") {
+        headers["X-Auth-Email"] = `${widget.email}`;
+        headers["X-Auth-Key"] = `${widget.key}`;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/cloudflared/component.jsx
+++ b/src/widgets/cloudflared/component.jsx
@@ -20,10 +20,12 @@ export default function Component({ service }) {
     );
   }
 
+  const originIP = statsData.result.connections?.origin_ip ?? statsData.result.connections[0]?.origin_ip;
+
   return (
     <Container service={service}>
-      <Block label="cloudflared.status" value={statsData.result.status} />
-      <Block label="cloudflared.origin_ip" value={statsData.result.connections.origin_ip} />
+      <Block label="cloudflared.status" value={statsData.result.status.charAt(0).toUpperCase() + statsData.result.status.slice(1)} />
+      <Block label="cloudflared.origin_ip" value={originIP} />
     </Container>
   );
 }

--- a/src/widgets/cloudflared/component.jsx
+++ b/src/widgets/cloudflared/component.jsx
@@ -3,7 +3,6 @@ import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
-  const { t } = useTranslation();
   const { widget } = service;
 
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "cfd_tunnel");
@@ -23,8 +22,8 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="cloudflared.status" value={statsData.status} />
-      <Block label="cloudflared.origin_ip" value={statsData.origin_ip} />
+      <Block label="cloudflared.status" value={statsData.result.status} />
+      <Block label="cloudflared.origin_ip" value={statsData.result.connections.origin_ip} />
     </Container>
   );
 }

--- a/src/widgets/cloudflared/component.jsx
+++ b/src/widgets/cloudflared/component.jsx
@@ -1,0 +1,30 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "cfd_tunnel");
+
+  if (statsError) {
+    return <Container error={statsError} />;
+  }
+
+  if (!statsData) {
+    return (
+      <Container service={service}>
+        <Block label="cloudflared.status" />
+        <Block label="cloudflared.origin_ip" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="cloudflared.status" value={statsData.status} />
+      <Block label="cloudflared.origin_ip" value={statsData.origin_ip} />
+    </Container>
+  );
+}

--- a/src/widgets/cloudflared/widget.js
+++ b/src/widgets/cloudflared/widget.js
@@ -1,12 +1,16 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
-  api: "https://api.cloudflare.com/client/v4/accounts/{accountid}/{endpoint}/{tunnelid}?",
+  api: "https://api.cloudflare.com/client/v4/accounts/{accountid}/{endpoint}/{tunnelid}",
   proxyHandler: credentialedProxyHandler,
 
   mappings: {
     "cfd_tunnel": {
       endpoint: "cfd_tunnel",
+      validate: [
+        "success",
+        "result"
+      ]
     },
   },
 };

--- a/src/widgets/cloudflared/widget.js
+++ b/src/widgets/cloudflared/widget.js
@@ -1,0 +1,18 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "https://api.cloudflare.com/client/v4/accounts/{accountid}/{endpoint}/{tunnelid}?",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    "cfd_tunnel": {
+      endpoint: "cfd_tunnel",
+      validate: [
+        "origin_ip",
+        "status",
+      ],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/cloudflared/widget.js
+++ b/src/widgets/cloudflared/widget.js
@@ -7,10 +7,6 @@ const widget = {
   mappings: {
     "cfd_tunnel": {
       endpoint: "cfd_tunnel",
-      validate: [
-        "origin_ip",
-        "status",
-      ],
     },
   },
 };

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -6,6 +6,7 @@ const components = {
   autobrr: dynamic(() => import("./autobrr/component")),
   bazarr: dynamic(() => import("./bazarr/component")),
   changedetectionio: dynamic(() => import("./changedetectionio/component")),
+  cloudflared: dynamic(() => import("./cloudflared/component")),
   coinmarketcap: dynamic(() => import("./coinmarketcap/component")),
   deluge: dynamic(() => import("./deluge/component")),
   downloadstation: dynamic(() => import("./downloadstation/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -3,6 +3,7 @@ import authentik from "./authentik/widget";
 import autobrr from "./autobrr/widget";
 import bazarr from "./bazarr/widget";
 import changedetectionio from "./changedetectionio/widget";
+import cloudflared from "./cloudflared/widget";
 import coinmarketcap from "./coinmarketcap/widget";
 import deluge from "./deluge/widget";
 import downloadstation from "./downloadstation/widget";
@@ -61,6 +62,7 @@ const widgets = {
   autobrr,
   bazarr,
   changedetectionio,
+  cloudflared,
   coinmarketcap,
   deluge,
   diskstation: downloadstation,


### PR DESCRIPTION
This reaches out to cloudflare using an API call and gets the status of the tunnel and the origin ip, as requested in a feature request.

Here is the services.yaml
```yaml
          widget:
            type: cloudflared
            email: fake@email.com
            accountid: <accountid> #this can be pulled from your dash page in the url
            tunnelid: <tunnelid> #this is pulled from your tunnel dashboard
            key: <apikey> #this is an api key you setup in your account at https://dash.cloudflare.com/profile/api-tokens
```
            
