### PR TITLE
Enhancement: support specifying widget fields in docker labels / kubernetes annotations

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -218,9 +218,11 @@ export function cleanServiceGroups(groups) {
           wan // opnsense widget
         } = cleanedService.widget;
 
+        const fieldsList = typeof fields === 'string' ? JSON.parse(fields) : fields;
+
         cleanedService.widget = {
           type,
-          fields: fields || null,
+          fields: fieldsList || null,
           service_name: service.name,
           service_group: serviceGroup.name,
         };


### PR DESCRIPTION
At least in Kubernetes, the field list is not being parsed. This PR detects if the fields list is a string and if it is parses it as JSON. This resolves the issue for Kubernetes widgets and should not disturb existing functionality.