### PR TITLE
Services are now sorted by a new 'weight' field

### DIFF
--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -13,6 +13,17 @@ import {
 } from "utils/config/service-helpers";
 import { cleanWidgetGroups, widgetsFromConfig } from "utils/config/widget-helpers";
 
+/**
+ * Compares services by weight then by name.
+ */
+function compareServices(service1, service2) {
+  const comp = service1.weight - service2.weight;
+  if (comp !== 0) {
+    return comp;
+  }
+  return service1.name.localeCompare(service2.name);
+}
+
 export async function bookmarksResponse() {
   checkAndCopyConfig("bookmarks.yaml");
 
@@ -112,7 +123,8 @@ export async function servicesResponse() {
         ...discoveredDockerGroup.services,
         ...discoveredKubernetesGroup.services,
         ...configuredGroup.services
-      ].filter((service) => service),
+      ].filter((service) => service)
+        .sort(compareServices),
     };
 
     if (definedLayouts) {

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -33,6 +33,15 @@ export async function servicesFromConfig() {
     })),
   }));
 
+  // add default weight to services based on their position in the configuration
+  servicesArray.forEach((group, groupIndex) => {
+    group.services.forEach((service, serviceIndex) => {
+      if(!service.weight) {
+        servicesArray[groupIndex].services[serviceIndex].weight = (serviceIndex + 1) * 100;
+      }
+    });
+  });
+
   return servicesArray;
 }
 
@@ -152,6 +161,7 @@ export async function servicesFromKubernetes() {
         href: ingress.metadata.annotations[`${ANNOTATION_BASE}/href`] || getUrlFromIngress(ingress),
         name: ingress.metadata.annotations[`${ANNOTATION_BASE}/name`] || ingress.metadata.name,
         group: ingress.metadata.annotations[`${ANNOTATION_BASE}/group`] || "Kubernetes",
+        weight: ingress.metadata.annotations[`${ANNOTATION_BASE}/weight`] || '0',
         icon: ingress.metadata.annotations[`${ANNOTATION_BASE}/icon`] || '',
         description: ingress.metadata.annotations[`${ANNOTATION_BASE}/description`] || '',
       };
@@ -201,6 +211,17 @@ export function cleanServiceGroups(groups) {
     name: serviceGroup.name,
     services: serviceGroup.services.map((service) => {
       const cleanedService = { ...service };
+      if (typeof service.weight === 'string') {
+        const weight = parseInt(service.weight, 10);
+        if (Number.isNaN(weight)) {
+          cleanedService.weight = 0;
+        } else {
+          cleanedService.weight = weight;
+        }
+      }
+      if (typeof cleanedService.weight !== "number") {
+        cleanedService.weight = 0;
+      }
 
       if (cleanedService.widget) {
         // whitelisted set of keys to pass to the frontend


### PR DESCRIPTION
* Default for discovered services is 0
* Default weight for configured services is their index within their group scaled by 100, i.e. (index + 1) * 100
* Should be backwards compatible with current loose ordering
* If two items have the same weight value, then they will be sorted by name

closes #673