### PR TITLE
Don't show QEMU templates in VMs field for Proxmox widget

### DIFF
--- a/src/widgets/proxmox/component.jsx
+++ b/src/widgets/proxmox/component.jsx
@@ -31,7 +31,7 @@ export default function Component({ service }) {
   }
 
   const { data } = clusterData ;
-  const vms = data.filter(item => item.type === "qemu") || [];
+  const vms = data.filter(item => item.type === "qemu" && item.template === 0) || [];
   const lxc = data.filter(item => item.type === "lxc" && item.template === 0) || [];
   const nodes = data.filter(item => item.type === "node") || [];
 


### PR DESCRIPTION
fixes #864