### PR TITLE
feat: Custom CSS

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -6,6 +6,7 @@ import Head from "next/head";
 import "styles/globals.css";
 import "styles/theme.css";
 import "styles/manrope.css";
+import "styles/custom.css";
 import nextI18nextConfig from "../../next-i18next.config";
 
 import { ColorProvider } from "utils/contexts/color";

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,0 +1,3 @@
+/*
+Mount this file and define your custom styles 
+*/


### PR DESCRIPTION
Hi @benphelps,
based on the discussions in #235, #139  and similar issue I have encountered myself (trying to insert a logo which I want to be wider than 48px), I would suggest adding support for custom css to cater for unique and custom usecases users may have. This way everyone can simply override the style they want to customize.

I'd be of course happy to update the docs accordingly in the benphelps/homepage-docs repo if this change is accepted.

Side note: I have considered adding custom styles via settings but it's troublesome because the imports must be static otherwise Webpack build fails. There could be probably ways to use dynamic import but tbh this seems much easier and transparent.