### PR TITLE
Fix: Show container status if health is an empty string

### DIFF
--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -30,8 +30,8 @@ export default function Status({ service }) {
     }
 
     return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.health ?? data.status}>
-        <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{data.health ?? data.status}</div>
+      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.health || data.status}>
+        <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{data.health || data.status}</div>
       </div>
     );
   }


### PR DESCRIPTION
If data.health is an empty string, ?? will accept it and not use the right side value; instead, we should use || which treats empty string as false and returns the right side value. This will show "RUNNING" in the status box if health is "".