### PR TITLE
Feature: Unifi widgets support non-default site

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -51,7 +51,8 @@
         "wlan_users": "WLAN Users",
         "up": "UP",
         "down": "DOWN",
-        "wait": "Please wait"
+        "wait": "Please wait",
+        "empty_data": "Subsystem status unknown"
     },
     "docker": {
         "rx": "RX",

--- a/src/components/widgets/unifi_console/unifi_console.jsx
+++ b/src/components/widgets/unifi_console/unifi_console.jsx
@@ -55,6 +55,8 @@ export default function Widget({ options }) {
   const name = wan.gw_name ?? defaultSite.desc;
   const uptime = wan["gw_system-stats"] ? wan["gw_system-stats"].uptime : null;
 
+  const dataEmpty = !(wan.show || lan.show || wlan.show || uptime);
+
   return (
     <div className="flex-none flex flex-row items-center mr-3 py-1.5">
       <div className="flex flex-col">
@@ -64,6 +66,14 @@ export default function Widget({ options }) {
             {name}
           </div>
         </div>
+        {dataEmpty && <div className="flex flex-row ml-3 text-[8px] justify-between">
+        <div className="flex flex-row items-center justify-end">
+          <div className="flex flex-row">
+            <BiError className="w-4 h-4 text-theme-800 dark:text-theme-200" />
+            <span className="text-theme-800 dark:text-theme-200 text-xs">{t("unifi.empty_data")}</span>
+          </div>
+        </div>
+      </div>}
         <div className="flex flex-row ml-3 text-[10px] justify-between">
           {uptime && <div className="flex flex-row" title={t("unifi.uptime")}>
             <div className="pr-0.5 text-theme-800 dark:text-theme-200">

--- a/src/components/widgets/unifi_console/unifi_console.jsx
+++ b/src/components/widgets/unifi_console/unifi_console.jsx
@@ -20,7 +20,6 @@ export default function Widget({ options }) {
             <BiError className="w-8 h-8 text-theme-800 dark:text-theme-200" />
             <div className="flex flex-col ml-3 text-left">
               <span className="text-theme-800 dark:text-theme-200 text-sm">{t("widget.api_error")}</span>
-              <span className="text-theme-800 dark:text-theme-200 text-xs">-</span>
             </div>
           </div>
         </div>
@@ -28,7 +27,7 @@ export default function Widget({ options }) {
     );
   }
 
-  const defaultSite = statsData?.data?.find(s => s.name === "default");
+  const defaultSite = options.site ? statsData?.data.find(s => s.desc === options.site) : statsData?.data?.find(s => s.name === "default");
 
   if (!defaultSite) {
     return (

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -233,6 +233,7 @@ export function cleanServiceGroups(groups) {
           currency, // coinmarketcap widget
           symbols,
           defaultinterval,
+          site, // unifi widget
           namespace, // kubernetes widget
           app,
           podSelector,
@@ -255,6 +256,9 @@ export function cleanServiceGroups(groups) {
         if (type === "docker") {
           if (server) cleanedService.widget.server = server;
           if (container) cleanedService.widget.container = container;
+        }
+        if (type === "unifi") {
+          if (site) cleanedService.widget.site = site;
         }
         if (type === "kubernetes") {
           if (namespace) cleanedService.widget.namespace = namespace;

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
         return <Container error={statsError} />;
     }
 
-    const defaultSite = statsData?.data?.find(s => s.name === "default");
+    const defaultSite = widget.site ? statsData?.data.find(s => s.desc === widget.site) : statsData?.data?.find(s => s.name === "default");
 
     if (!defaultSite) {
         return (

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -38,6 +38,14 @@ export default function Component({ service }) {
 
     const uptime = wan["gw_system-stats"] ? `${t("common.number", { value: wan["gw_system-stats"].uptime / 86400, maximumFractionDigits: 1 })} ${t("unifi.days")}` : null;
 
+    if (!(wan.show || lan.show || wlan.show || uptime)) {
+        return (
+            <Container service={service}>
+                <Block value={ t("unifi.empty_data") } />
+            </Container>
+        )
+    }
+
     return (
         <Container service={service}>
             {uptime && <Block label="unifi.uptime" value={ uptime } />}


### PR DESCRIPTION
Two things:

- Support other sites (now allows `site` key with name)
- When no [useful] data is returned from a controller currently it looks like there's no widget (and no error is shown), now it shows this to the user

Closes #706 
Closes #926