### PR TITLE
Fix settings after container update

### DIFF
--- a/src/pages/api/hash.js
+++ b/src/pages/api/hash.js
@@ -19,7 +19,10 @@ export default async function handler(req, res) {
     return hash(readFileSync(configYaml, "utf8"));
   });
 
-  const combinedHash = hash(hashes.join(""));
+  // this ties hash to specific build which should force revaliation between versions
+  const buildTime = process.env.NEXT_PUBLIC_BUILDTIME?.length ? process.env.NEXT_PUBLIC_BUILDTIME : '';
+
+  const combinedHash = hash(hashes.join("") + buildTime);
 
   res.send({
     hash: combinedHash,

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -100,7 +100,7 @@ function Index({ initialSettings, fallback }) {
           localStorage.setItem("hash", hashData.hash);
         }
 
-        if (!initialSettings.isValid || (previousHash && previousHash !== hashData.hash)) {
+        if (previousHash && previousHash !== hashData.hash) {
           setStale(true);
           localStorage.setItem("hash", hashData.hash);
 
@@ -112,7 +112,7 @@ function Index({ initialSettings, fallback }) {
         }
       }
     }
-  }, [hashData, initialSettings]);
+  }, [hashData]);
 
   if (stale) {
     return (

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { join } from "path";
-import { existsSync, copyFile, readFileSync, statSync } from "fs";
+import { existsSync, copyFile, readFileSync } from "fs";
 
 import yaml from "js-yaml";
 
@@ -32,18 +32,5 @@ export function getSettings() {
 
   const settingsYaml = join(process.cwd(), "config", "settings.yaml");
   const fileContents = readFileSync(settingsYaml, "utf8");
-
-  let stats;
-  try {
-    stats = statSync(settingsYaml);
-  } catch (e) {
-    stats = {};
-  }
-
-  const yamlLoaded = yaml.load(fileContents) ?? {};
-
-  return { 
-    ...yamlLoaded,
-    isValid: fileContents !== "-\n" && stats.size !== 2 // see https://github.com/benphelps/homepage/pull/609
-  };
+  return yaml.load(fileContents) ?? {};
 }


### PR DESCRIPTION
Ok, this is another approach to try and fix #576 (and it reverts the other attempt).

The idea here is to include `NEXT_PUBLIC_BUILDTIME` in the config hash, which in effect will force revalidation after the container is updated even if the settings haven't changed.

It's not perfect, if someone recreates the container it'll still happen and folks building their own image will need to supply the build time arg for this to work. But for the majority of users who are seeing this e.g. after watchtower updates this should help.

Still welcome other solutions here, especially to the post-recreation part

Closes #576 (again)