### PR TITLE
Fix: cookieJar.setCookieSync ignore error

### DIFF
--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -33,8 +33,7 @@ export function addCookieToJar(url, headers) {
     cookies = [cookie];
   }
 
-  const options = { ignoreError: true };
   for (let i = 0; i < cookies.length; i += 1) {
-    cookieJar.setCookieSync(cookies[i], url.toString(), options);
+    cookieJar.setCookieSync(cookies[i], url.toString(), { ignoreError: true });
   }
 }

--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -33,7 +33,8 @@ export function addCookieToJar(url, headers) {
     cookies = [cookie];
   }
 
+  const options = { ignoreError: true };
   for (let i = 0; i < cookies.length; i += 1) {
-    cookieJar.setCookieSync(cookies[i], url.toString());
+    cookieJar.setCookieSync(cookies[i], url.toString(), options);
   }
 }


### PR DESCRIPTION
cookieJar.setCookieSync crash node when error, like:
```
uncaughtException: Error: Cookie not in this host's domain. Cookie:example.com Request:127.0.0.1
```