### PR TITLE
Added support for "ping" configuration in kubernetes ingress annotations

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -168,6 +168,9 @@ export async function servicesFromKubernetes() {
       if (ingress.metadata.annotations[ANNOTATION_POD_SELECTOR]) {
         constructedService.podSelector = ingress.metadata.annotations[ANNOTATION_POD_SELECTOR];
       }
+      if (ingress.metadata.annotations[`${ANNOTATION_BASE}/ping`]) {
+        constructedService.ping = ingress.metadata.annotations[`${ANNOTATION_BASE}/ping`];
+      }
       Object.keys(ingress.metadata.annotations).forEach((annotation) => {
         if (annotation.startsWith(ANNOTATION_WIDGET_BASE)) {
           shvl.set(constructedService, annotation.replace(`${ANNOTATION_BASE}/`, ""), ingress.metadata.annotations[annotation]);


### PR DESCRIPTION
This adds the missing support for "ping" in Kubernetes ingress. It can be used as follows:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: pihole
  annotations:
    gethomepage.dev/enabled: "true"
    gethomepage.dev/name: PiHole
    gethomepage.dev/description: Ad Blocker and Local DNS
    gethomepage.dev/group: Admin
    gethomepage.dev/ping: "https://pihole.my.network/admin"
    gethomepage.dev/icon: pihole.png
    gethomepage.dev/widget.type: "pihole"
    gethomepage.dev/widget.url: "https://pihole.my.network"
    gethomepage.dev/widget.key: "secretwidgetkey"
spec:
  rules:
  - host: pihole.my.network
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: pihole
            port:
              number: 80
```

Fixes #957