### PR TITLE
Move the footer to the bottom

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -252,7 +252,7 @@ function Home({ initialSettings }) {
         />
         <meta name="theme-color" content={themes[initialSettings.color || "slate"][initialSettings.theme || "dark"]} />
       </Head>
-      <div className="relative container m-auto flex flex-col justify-between z-10">
+      <div className="relative container m-auto flex flex-col justify-between z-10 h-full">
         <div
           className={classNames(
             "flex flex-row flex-wrap  justify-between",


### PR DESCRIPTION
I moved the footer to the bottom of the screen.

If the home page is smaller than a screen (for example, without bookmarks), the footer is in the middle of the screen. I made the max page height to move the footer down.