### PR TITLE
Fix: improve swarm status for replicated services & prefer stats for local containers

### DIFF
--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -12,7 +12,7 @@ export default function Status({ service }) {
     </div>
   }
 
-  if (data && data.status === "running") {
+  if (data && data.status.includes("running")) {
     if (data.health === "starting") {
       return (
         <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.health}>
@@ -36,7 +36,7 @@ export default function Status({ service }) {
     );
   }
 
-  if (data && (data.status === "not found" || data.status === "exited")) {
+  if (data && (data.status === "not found" || data.status === "exited" || data.status?.startsWith("partial"))) {
     return (
       <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.status}>
         <div className="text-[8px] font-bold text-orange-400/50 dark:text-orange-400/80 uppercase">{data.status}</div>

--- a/src/widgets/docker/component.jsx
+++ b/src/widgets/docker/component.jsx
@@ -22,7 +22,7 @@ export default function Component({ service }) {
     return <Container error={finalError} />;
   }
 
-  if (statusData && statusData.status !== "running") {
+  if (statusData && !(statusData.status.includes("running") || statusData.status.includes("partial"))) {
     return (
       <Container>
         <Block label={t("widget.status")} value={t("docker.offline")} />


### PR DESCRIPTION
Digging into swarm a bit, currently the code just chooses the 0th task for a service which might be on a different node, in which case we can't get container stats, so this PR tries to find one running locally which fixes the status and stats badge (though stats are still only for 1 task as current).

Closes #970 (which may actually be partly a separate issue too)

@vinaydawani would be great if you could check this out, again Im just playing with swarm for testing purposes...

Edit: this now also contains changes from #998 which improved swarm status with N replicas info