### PR TITLE
Improve Docker Swarm status check

### DIFF
--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -7,15 +7,21 @@ export default function Status({ service }) {
   const { data, error } = useSWR(`/api/docker/status/${service.container}/${service.server || ""}`);
 
   if (error) {
-    <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.status}>
+    <div
+      className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden"
+      title={data.status}
+    >
       <div className="text-[8px] font-bold text-rose-500/80 uppercase">{t("docker.error")}</div>
-    </div>
+    </div>;
   }
 
   if (data && data.status === "running") {
     if (data.health === "starting") {
       return (
-        <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.health}>
+        <div
+          className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden"
+          title={data.health}
+        >
           <div className="text-[8px] font-bold text-blue-500/80 uppercase">{data.health}</div>
         </div>
       );
@@ -23,22 +29,31 @@ export default function Status({ service }) {
 
     if (data.health === "unhealthy") {
       return (
-        <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.health}>
+        <div
+          className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden"
+          title={data.health}
+        >
           <div className="text-[8px] font-bold text-orange-400/50 dark:text-orange-400/80 uppercase">{data.health}</div>
         </div>
       );
     }
 
     return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.health || data.status}>
+      <div
+        className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden"
+        title={data.health || data.status}
+      >
         <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{data.health || data.status}</div>
       </div>
     );
   }
 
-  if (data && (data.status === "not found" || data.status === "exited")) {
+  if (data && (data.status === "not found" || data.status === "exited" || data.status?.startsWith("partial"))) {
     return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={data.status}>
+      <div
+        className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden"
+        title={data.status}
+      >
         <div className="text-[8px] font-bold text-orange-400/50 dark:text-orange-400/80 uppercase">{data.status}</div>
       </div>
     );


### PR DESCRIPTION
This PR improves the docker swarm status by checking the mode (replicated or global) and if the number of tasks corresponds to the expected one.

This also removes the `Docker.Container.inspect()` method that couldn't work if the container was not on the manager node (addressing PR #970)

Remark:
The only problem that remains is for the stats where it will only work if the container is on the manager. There is (as far as I know) no way to prevent this considering the actual Docker API.