### PR TITLE
Feature: strip sensitive information contained in URLs from frontend API calls

### DIFF
--- a/src/utils/proxy/api-helpers.js
+++ b/src/utils/proxy/api-helpers.js
@@ -53,3 +53,12 @@ export function jsonArrayTransform(data, transform) {
 export function jsonArrayFilter(data, filter) {
   return jsonArrayTransform(data, (items) => items.filter(filter));
 }
+
+export function sanitizeErrorURL(errorURL) {
+  // Dont display sensitive params on frontend
+  const url = new URL(errorURL);
+  ["apikey", "api_key", "token", "t"].forEach(key => {
+    if (url.searchParams.has(key)) url.searchParams.set(key, "***")
+  });
+  return url.toString();
+}

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -1,5 +1,5 @@
 import getServiceWidget from "utils/config/service-helpers";
-import { formatApiCall } from "utils/proxy/api-helpers";
+import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
 import validateWidgetData from "utils/proxy/validate-widget-data";
 import { httpProxy } from "utils/proxy/http";
 import createLogger from "utils/logger";
@@ -68,7 +68,10 @@ export default async function credentialedProxyHandler(req, res, map) {
       }
 
       if (!validateWidgetData(widget, endpoint, data)) {
-        return res.status(500).json({error: {message: "Invalid data", url, data}});
+        if (data.error && data.error.url) {
+          data.error.url = sanitizeErrorURL(url);
+        }
+        return res.status(500).json({error: {message: "Invalid data", url: sanitizeErrorURL(url), data}});
       }
 
       if (status === 200 && map) {


### PR DESCRIPTION
In the end it's not that many widgets but some contain sensitive information in the URL e.g. API key, not only do we want to prevent display but prevent data from being returned to frontend at all, so strip it server-side. For better or worse this is an 'exclude' list rather than an 'allow'. Again I believe this covers the current cases, certainly the two noted in the linked issues.

<img width="494" alt="Screenshot 2023-02-15 at 2 37 04 PM" src="https://user-images.githubusercontent.com/4887959/219206187-8bc11e1a-092b-4761-af29-e15089d66c5d.png">

Fixes #896 
Fixes #1001