### PR TITLE
Fix: Correct flood + transmission rate units

### DIFF
--- a/src/widgets/flood/component.jsx
+++ b/src/widgets/flood/component.jsx
@@ -45,9 +45,9 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="flood.leech" value={t("common.number", { value: leech })} />
-      <Block label="flood.download" value={t("common.bitrate", { value: rateDl })} />
+      <Block label="flood.download" value={t("common.byterate", { value: rateDl })} />
       <Block label="flood.seed" value={t("common.number", { value: completed })} />
-      <Block label="flood.upload" value={t("common.bitrate", { value: rateUl })} />
+      <Block label="flood.upload" value={t("common.byterate", { value: rateUl })} />
     </Container>
   );
 }

--- a/src/widgets/transmission/component.jsx
+++ b/src/widgets/transmission/component.jsx
@@ -36,9 +36,9 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="transmission.leech" value={t("common.number", { value: leech })} />
-      <Block label="transmission.download" value={t("common.bitrate", { value: rateDl * 8 })} />
+      <Block label="transmission.download" value={t("common.byterate", { value: rateDl })} />
       <Block label="transmission.seed" value={t("common.number", { value: completed })} />
-      <Block label="transmission.upload" value={t("common.bitrate", { value: rateUl * 8 })} />
+      <Block label="transmission.upload" value={t("common.byterate", { value: rateUl })} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

Convert Flood download and upload rates from B/s to b/s

Closes #1021

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
