### PR TITLE
Add Health checks widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -354,6 +354,16 @@
         "child_bridges": "Child Bridges",
         "child_bridges_status": "{{ok}}/{{total}}"
     },
+    "healthchecks": {
+        "new": "New",
+        "up": "Online",
+        "grace": "In Grace Period",
+        "down": "Offline",
+        "paused": "Paused",
+        "status": "Status",
+        "last_ping": "Last Ping",
+        "never": "No pings yet"
+    },
     "watchtower": {
         "containers_scanned": "Scanned",
         "containers_updated": "Updated",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -21,6 +21,7 @@ const components = {
   grafana: dynamic(() => import("./grafana/component")),
   hdhomerun: dynamic(() => import("./hdhomerun/component")),
   homebridge: dynamic(() => import("./homebridge/component")),
+  healthchecks: dynamic(() => import("./healthchecks/component")),
   jackett: dynamic(() => import("./jackett/component")),
   jellyfin: dynamic(() => import("./emby/component")),
   jellyseerr: dynamic(() => import("./jellyseerr/component")),

--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -1,5 +1,7 @@
 import { useTranslation } from "next-i18next";
 
+import { i18n } from "../../../next-i18next.config";
+
 import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import useWidgetAPI from "utils/proxy/use-widget-api";
@@ -7,22 +9,18 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 function formatDate(dateString) {
   const date = new Date(dateString);
   const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const diff = (now - date) / 1000;
-
-  if (date > today && diff < 86400) {
-    return date.toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "numeric",
-    });
-  }
-
-  return date.toLocaleDateString([], {
-    month: "short",
+  let dateOptions = {
+    month: "numeric",
     day: "numeric",
     hour: "numeric",
     minute: "numeric",
-  });
+  };
+  
+  if (date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth() && date.getDate() === now.getDate()) {
+    dateOptions = { timeStyle: "short" };
+  }
+  
+  return new Intl.DateTimeFormat(i18n.language, dateOptions).format(date);
 }
 
 export default function Component({ service }) {

--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -1,0 +1,56 @@
+import { useTranslation } from "next-i18next";
+
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function formatDate(dateString) {
+  const date = new Date(dateString);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diff = (now - date) / 1000;
+
+  if (date > today && diff < 86400) {
+    return date.toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "numeric",
+    });
+  }
+
+  return date.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  });
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data, error } = useWidgetAPI(widget, "checks");
+
+  if (error) {
+    return <Container error={error} />;
+  }
+
+  if (!data) {
+    return (
+      <Container service={service}>
+        <Block label={t("healthchecks.status")} />
+        <Block label={t("healthchecks.last_ping")} />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label={t("healthchecks.status")} value={t(`healthchecks.${data.status}`)} />
+      <Block
+        label={t("healthchecks.last_ping")}
+        value={data.last_ping ? formatDate(data.last_ping) : t("healthchecks.never")}
+      />
+    </Container>
+  );
+}

--- a/src/widgets/healthchecks/widget.js
+++ b/src/widgets/healthchecks/widget.js
@@ -1,0 +1,18 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "https://healthchecks.io/api/v2/{endpoint}/{uuid}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    checks: {
+      endpoint: "checks",
+      validate: [
+        "status",
+        "last_ping",
+      ]
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -16,6 +16,7 @@ import gotify from "./gotify/widget";
 import grafana from "./grafana/widget";
 import hdhomerun from "./hdhomerun/widget";
 import homebridge from "./homebridge/widget";
+import healthchecks from "./healthchecks/widget";
 import jackett from "./jackett/widget";
 import jellyseerr from "./jellyseerr/widget";
 import komga from "./komga/widget";
@@ -87,6 +88,7 @@ const widgets = {
   grafana,
   hdhomerun,
   homebridge,
+  healthchecks,
   jackett,
   jellyfin: emby,
   jellyseerr,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

First time open source contributor.

I implemented a widget for [healthchecks.io](https://healthchecks.io/). It shows the current status of a project. (online, offline, etc)

This closes https://github.com/benphelps/homepage/issues/965

<img width="251" alt="image" src="https://user-images.githubusercontent.com/52141915/219939876-969ecd72-35d9-4872-8918-42d4cb823f70.png">
<img width="248" alt="image" src="https://user-images.githubusercontent.com/52141915/219939835-fafcd86a-0467-4f6e-8b7f-60601b8c3acc.png">
<img width="247" alt="image" src="https://user-images.githubusercontent.com/52141915/219939816-40d7307e-bda4-401d-aec9-c3af1eac2df5.png">

### Widget configuration
    widget:
        type: healthchecks
        key: <YOUR_API_KEY>
        uuid: <YOUR_CHECK_UUID>

Let me know if you need any changes done. 👍

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/39
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
