### PR TITLE
Fix homebridge config UI-X API expires login with 403

### DIFF
--- a/src/widgets/homebridge/proxy.js
+++ b/src/widgets/homebridge/proxy.js
@@ -50,7 +50,7 @@ async function apiCall(widget, endpoint, service) {
     headers,
   });
 
-  if (status === 401) {
+  if (status === 401 || status === 403) {
     logger.debug("Homebridge API rejected the request, attempting to obtain new session token");
     const { accessToken } = login(widget, service);
     headers.Authorization = `Bearer ${accessToken}`;
@@ -63,7 +63,7 @@ async function apiCall(widget, endpoint, service) {
   }
 
   if (status !== 200) {
-    logger.error("Error getting data from Homebridge: %d.  Data: %s", status, data);
+    logger.error("Error getting data from Homebridge: %s status %d. Data: %s", url, status, data);
   }
 
   return { status, contentType, data: JSON.parse(data.toString()), responseHeaders };


### PR DESCRIPTION
## Proposed change

Seems something changed in recent home bridge version, the API kicks back login credentials long before expiration with a 403, remedy is just to login again.

Closes #1025

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
