### PR TITLE
Added "external" boolean annotation to specify external services

### DIFF
--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -91,7 +91,7 @@ export default function Item({ service }) {
                   <span className="sr-only">View container stats</span>
                 </button>
               )}
-              {service.app && (
+              {(service.app && !service.external) && (
                 <button
                   type="button"
                   onClick={() => (statsOpen ? closeStats() : setStatsOpen(true))}

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -164,7 +164,11 @@ export async function servicesFromKubernetes() {
         weight: ingress.metadata.annotations[`${ANNOTATION_BASE}/weight`] || '0',
         icon: ingress.metadata.annotations[`${ANNOTATION_BASE}/icon`] || '',
         description: ingress.metadata.annotations[`${ANNOTATION_BASE}/description`] || '',
+        external: false,
       };
+      if (ingress.metadata.annotations[`${ANNOTATION_BASE}/external`]) {
+        constructedService.external = String(ingress.metadata.annotations[`${ANNOTATION_BASE}/external`]).toLowerCase() === "true"
+      }
       if (ingress.metadata.annotations[ANNOTATION_POD_SELECTOR]) {
         constructedService.podSelector = ingress.metadata.annotations[ANNOTATION_POD_SELECTOR];
       }


### PR DESCRIPTION
## Proposed change

External services define a kubernetes service pointing to an application hosted outside of the cluster. These services should not attempt to get the status based on kubernetes deployments. The new boolean flag disables this functionality. Since this is an edge case, the default value is "false".

Prior to this change the system would attempt to find a matching deployment and fail, resulting in a "not found" error and small box in the top right corner.

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: uptimekuma
  annotations:
    gethomepage.dev/enabled: "true"
    gethomepage.dev/name: Uptime Kuma
    gethomepage.dev/description: Service Uptime Monitoring
    gethomepage.dev/group: Admin
    gethomepage.dev/url: "https://uptime.k3d.localhost"
    gethomepage.dev/icon: uptime-kuma.png
    gethomepage.dev/external: "true"
```

This is a follow up to #957

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
