### PR TITLE
Added support for environment variable substitution

### DIFF
--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -4,7 +4,7 @@ import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { getSettings } from "utils/config/config";
+import checkAndCopyConfig, { getSettings, substituteEnvironmentVars } from "utils/config/config";
 import {
   servicesFromConfig,
   servicesFromDocker,
@@ -28,7 +28,8 @@ export async function bookmarksResponse() {
   checkAndCopyConfig("bookmarks.yaml");
 
   const bookmarksYaml = path.join(process.cwd(), "config", "bookmarks.yaml");
-  const fileContents = await fs.readFile(bookmarksYaml, "utf8");
+  const rawFileContents = await fs.readFile(bookmarksYaml, "utf8");
+  const fileContents = substituteEnvironmentVars(rawFileContents);
   const bookmarks = yaml.load(fileContents);
 
   if (!bookmarks) return [];

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -27,10 +27,28 @@ export default function checkAndCopyConfig(config) {
   }
 }
 
+export function substituteEnvironmentVars(str) {
+  const homepageVarPrefix = "HOMEPAGE_VAR_";
+  const homepageFilePrefix = "HOMEPAGE_FILE_";
+
+  let result = str;
+  Object.keys(process.env).forEach(key => {
+    if (key.startsWith(homepageVarPrefix)) {
+      result = result.replaceAll(`{{${key}}}`, process.env[key]);
+    } else if (key.startsWith(homepageFilePrefix)) {
+      const filename = process.env[key];
+      const fileContents = readFileSync(filename, "utf8");
+      result = result.replaceAll(`{{${key}}}`, fileContents);
+    }
+  });
+  return result;
+}
+
 export function getSettings() {
   checkAndCopyConfig("settings.yaml");
 
   const settingsYaml = join(process.cwd(), "config", "settings.yaml");
-  const fileContents = readFileSync(settingsYaml, "utf8");
+  const rawFileContents = readFileSync(settingsYaml, "utf8");
+  const fileContents = substituteEnvironmentVars(rawFileContents);
   return yaml.load(fileContents) ?? {};
 }

--- a/src/utils/config/docker.js
+++ b/src/utils/config/docker.js
@@ -3,13 +3,14 @@ import { readFileSync } from "fs";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig from "utils/config/config";
+import checkAndCopyConfig, { substituteEnvironmentVars } from "utils/config/config";
 
 export default function getDockerArguments(server) {
   checkAndCopyConfig("docker.yaml");
 
   const configFile = path.join(process.cwd(), "config", "docker.yaml");
-  const configData = readFileSync(configFile, "utf8");
+  const rawConfigData = readFileSync(configFile, "utf8");
+  const configData = substituteEnvironmentVars(rawConfigData);
   const servers = yaml.load(configData);
 
   if (!server) {

--- a/src/utils/config/kubernetes.js
+++ b/src/utils/config/kubernetes.js
@@ -4,13 +4,14 @@ import { readFileSync } from "fs";
 import yaml from "js-yaml";
 import { KubeConfig } from "@kubernetes/client-node";
 
-import checkAndCopyConfig from "utils/config/config";
+import checkAndCopyConfig, { substituteEnvironmentVars } from "utils/config/config";
 
 export default function getKubeConfig() {
   checkAndCopyConfig("kubernetes.yaml");
 
   const configFile = path.join(process.cwd(), "config", "kubernetes.yaml");
-  const configData = readFileSync(configFile, "utf8");
+  const rawConfigData = readFileSync(configFile, "utf8");
+  const configData = substituteEnvironmentVars(rawConfigData);
   const config = yaml.load(configData);
   const kc = new KubeConfig();
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -7,17 +7,19 @@ import * as shvl from "shvl";
 import { NetworkingV1Api } from "@kubernetes/client-node";
 
 import createLogger from "utils/logger";
-import checkAndCopyConfig from "utils/config/config";
+import checkAndCopyConfig, { substituteEnvironmentVars } from "utils/config/config";
 import getDockerArguments from "utils/config/docker";
 import getKubeConfig from "utils/config/kubernetes";
 
 const logger = createLogger("service-helpers");
 
+
 export async function servicesFromConfig() {
   checkAndCopyConfig("services.yaml");
 
   const servicesYaml = path.join(process.cwd(), "config", "services.yaml");
-  const fileContents = await fs.readFile(servicesYaml, "utf8");
+  const rawFileContents = await fs.readFile(servicesYaml, "utf8");
+  const fileContents = substituteEnvironmentVars(rawFileContents);
   const services = yaml.load(fileContents);
 
   if (!services) {
@@ -49,7 +51,8 @@ export async function servicesFromDocker() {
   checkAndCopyConfig("docker.yaml");
 
   const dockerYaml = path.join(process.cwd(), "config", "docker.yaml");
-  const dockerFileContents = await fs.readFile(dockerYaml, "utf8");
+  const rawDockerFileContents = await fs.readFile(dockerYaml, "utf8");
+  const dockerFileContents = substituteEnvironmentVars(rawDockerFileContents);
   const servers = yaml.load(dockerFileContents);
 
   if (!servers) {

--- a/src/utils/config/widget-helpers.js
+++ b/src/utils/config/widget-helpers.js
@@ -3,7 +3,7 @@ import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig from "utils/config/config";
+import checkAndCopyConfig, { substituteEnvironmentVars } from "utils/config/config";
 
 const exemptWidgets = ["search"];
 
@@ -11,7 +11,8 @@ export async function widgetsFromConfig() {
     checkAndCopyConfig("widgets.yaml");
 
     const widgetsYaml = path.join(process.cwd(), "config", "widgets.yaml");
-    const fileContents = await fs.readFile(widgetsYaml, "utf8");
+    const rawFileContents = await fs.readFile(widgetsYaml, "utf8");
+    const fileContents = substituteEnvironmentVars(rawFileContents);
     const widgets = yaml.load(fileContents);
 
     if (!widgets) return [];


### PR DESCRIPTION
## Proposed change

* Only environment variables starting with HOMEPAGE_VAR_ and HOMEPAGE_FILE_ are supported
* The value of env var HOMEPAGE_VAR_XXX will replace {{HOMEPAGE_VAR_XXX}} in any config
* The value of env var HOMEPAGE_FILE_XXX must be a file path, the contents of which will be used to replace {{HOMEPAGE_FILE_XXX}} in any config
* If a substituted value contains a variable reference it may also be replaced, but the behavior is non-deterministic

Closes #60 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
