### PR TITLE
Migrated helm chart from jameswynn/helm-charts

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -1,0 +1,25 @@
+name: Chart Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v2
+description: Chart for benphelps' Homepage
+icon: https://github.com/benphelps/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
+name: homepage
+version: 0.1.0
+appVersion: v0.6.9
+sources:
+  - https://github.com/benphelps/homepage/charts/homepage
+  - https://github.com/benphelps/homepage/
+maintainers:
+  - name: jameswynn
+dependencies:
+  - name: common
+    repository: https://bjw-s.github.io/helm-charts
+    version: 1.2.3
+annotations:
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial version

--- a/charts/homepage/ci/test-values.yaml
+++ b/charts/homepage/ci/test-values.yaml
@@ -1,0 +1,36 @@
+image:
+  repository: ghcr.io/benphelps/homepage
+  tag: kubernetes
+  pullPolicy: Always
+
+enableRbac: true
+
+serviceAccount:
+  create: true
+  name: homepage-test
+
+config:
+  kubernetes:
+    mode: cluster
+  widgets:
+    - resources:
+        backend: kubernetes
+        expanded: true
+        cpu: true
+        memory: true
+
+ingress:
+  main:
+    enabled: true
+    labels:
+      homepage/enabled: "true"
+    annotations:
+      homepage/name: "Homepage"
+      homepage/description: "A modern, secure, highly customizable application dashboard."
+      homepage/group: "My Group"
+      homepage/icon: "homepage.png"
+    hosts:
+      - host: &host "homepage.bogusdomain.test"
+        paths:
+          - path: /
+            pathType: Prefix

--- a/charts/homepage/readme.md
+++ b/charts/homepage/readme.md
@@ -1,0 +1,48 @@
+# Homepage (benphelps)
+
+A modern (fully static, fast), secure (fully proxied), highly customizable application dashboard with integrations for more than 25 services and translations for over 15 languages. Easily configured via YAML files (or discovery via docker labels).
+
+[Homepage](https://github.com/benphelps/homepage)
+
+## TL;DR
+
+```bash
+helm repo add homepage http://benphelps.github.io/homepage
+helm install my-release homepage/homepage
+```
+
+## Introduction
+
+This chart bootstraps a [Homepage](https://github.com/benphelps/homepage) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm install my-release homepage/homepage
+```
+
+The command deploys Homepage on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release
+```
+
+## Parameters
+
+This chart is based on [bjw-s library](https://bjw-s.github.io/helm-charts/docs/common-library/introduction/) and
+shares many configuration options with its derived [app-template](https://bjw-s.github.io/helm-charts/docs/app-template/introduction/).
+
+See the [values files](values.yaml) for more examples.

--- a/charts/homepage/templates/common.yaml
+++ b/charts/homepage/templates/common.yaml
@@ -1,0 +1,31 @@
+---
+{{- include "bjw-s.common.loader.init" . }}
+
+{{- define "app-template.hardcodedValues" -}}
+
+# Set the nameOverride based on the release name if no override has been set
+{{ if not .Values.global.nameOverride }}
+global:
+  nameOverride: "{{ .Release.Name }}"
+{{ end }}
+
+{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "app-template.hardcodedValues" . | fromYaml) -}}
+
+{{/* Append the configMap volume to the volumes */}}
+{{- define "homepage.configVolume" -}}
+enabled: "true"
+mountPath: "/app/config"
+type: "custom"
+volumeSpec:
+  configMap:
+    name: {{ (default (include "bjw-s.common.lib.chart.names.fullname" .) .Values.config.useExistingConfigMap) }}
+{{- end -}}
+{{- $_ := set .Values.persistence "homepage-config" (include "homepage.configVolume" . | fromYaml) -}}
+
+{{ if .Values.enableRbac }}
+{{- $_ := set .Values.serviceAccount "create" "true" -}}
+{{ end }}
+
+{{/* Render the templates */}}
+{{ include "bjw-s.common.loader.generate" . }}

--- a/charts/homepage/templates/configmap.yaml
+++ b/charts/homepage/templates/configmap.yaml
@@ -1,0 +1,34 @@
+{{ if not .Values.config.useExistingConfigMap }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bjw-s.common.lib.chart.names.fullname" . }}
+  labels:
+    {{- include "bjw-s.common.lib.metadata.allLabels" . | nindent 4 }}
+data:
+  bookmarks.yaml: {{- if .Values.config.bookmarks }} |
+{{- .Values.config.bookmarks | toYaml | nindent 4}}
+{{- else }} ""
+{{- end }}
+  docker.yaml: {{- if .Values.config.docker }} |
+{{- .Values.config.docker | toYaml | nindent 4 }}
+{{- else }} ""
+{{- end }}
+  kubernetes.yaml: {{- if .Values.config.kubernetes }} |
+{{- .Values.config.kubernetes | toYaml | nindent 4 }}
+{{- else }} ""
+{{- end }}
+  services.yaml: {{- if .Values.config.services }} |
+{{- .Values.config.services | toYaml | nindent 4 }}
+{{- else }} ""
+{{- end }}
+  settings.yaml: {{- if .Values.config.settings }} |
+{{- .Values.config.settings | toYaml | nindent 4 }}
+{{- else }} ""
+{{- end }}
+  widgets.yaml: {{- if .Values.config.widgets }} |
+{{- .Values.config.widgets | toYaml | nindent 4 }}
+{{- else }} ""
+{{- end }}
+{{ end }}

--- a/charts/homepage/templates/rbac.yaml
+++ b/charts/homepage/templates/rbac.yaml
@@ -1,0 +1,71 @@
+{{- include "bjw-s.common.loader.init" . }}
+{{ if .Values.enableRbac }}
+{{- $serviceAccountName := include "bjw-s.common.lib.chart.names.serviceAccountName" . -}}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ $serviceAccountName }}
+  {{- with (merge (.Values.labels | default dict) (include "bjw-s.common.lib.metadata.allLabels" $ | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    kubernetes.io/service-account.name: {{ $serviceAccountName }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $serviceAccountName }}
+  {{- with (merge (.Values.labels | default dict) (include "bjw-s.common.lib.metadata.allLabels" $ | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with (merge (.Values.annotations | default dict) (include "bjw-s.common.lib.metadata.globalAnnotations" $ | fromYaml)) }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $serviceAccountName }}
+  {{- with (merge (.Values.labels | default dict) (include "bjw-s.common.lib.metadata.allLabels" $ | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with (merge (.Values.annotations | default dict) (include "bjw-s.common.lib.metadata.globalAnnotations" $ | fromYaml)) }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $serviceAccountName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -1,0 +1,114 @@
+image:
+  repository: ghcr.io/benphelps/homepage
+  # tag: v0.6.0
+
+# Enable RBAC. RBAC is necessary to use Kubernetes integration
+enableRbac: false
+
+serviceAccount:
+  # Specify a different service account name
+  name: homepage
+  # Create service account. Needed when RBAC is enabled.
+  create: false
+
+service:
+  main:
+    ports:
+      http:
+        port: 3000
+
+controller:
+  strategy: RollingUpdate
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+
+# Enable the ingress to expose Homepage to the network.
+ingress:
+  main:
+    enabled: false
+    # labels:
+    #   # This label will enable discover of this deployment in Homepage
+    #   gethomepage.dev/enabled: "true"
+    # annotations:
+    #   # These annotations will configure how this deployment is shown in Homepage
+    #   gethomepage.dev/name: "Homepage"
+    #   gethomepage.dev/description: "A modern, secure, highly customizable application dashboard."
+    #   gethomepage.dev/group: "A New Group"
+    #   gethomepage.dev/icon: "homepage.png"
+    # ingressClassName: "nginx"
+    # hosts:
+    #   - host: &host "homepage.local"
+    #     paths:
+    #       - path: /
+    #         pathType: Prefix
+    # tls:
+    #   - hosts:
+    #       - *host
+
+# All the config files for Homepage can be specified under their relevant config block.
+config:
+  # To use an existing ConfigMap uncomment this line and specify the name
+  # useExistingConfigMap: existing-homepage-configmap
+  bookmarks:
+    - Developer:
+        - Github:
+            - abbr: GH
+              href: https://github.com/
+  services:
+    - My First Group:
+        - My First Service:
+            href: http://localhost/
+            description: Homepage is awesome
+
+    - My Second Group:
+        - My Second Service:
+            href: http://localhost/
+            description: Homepage is the best
+
+    - My Third Group:
+        - My Third Service:
+            href: http://localhost/
+            description: Homepage is 😎
+  widgets:
+    - resources:
+        # change backend to 'kubernetes' to use Kubernetes integration. Requires RBAC.
+        backend: resources
+        expanded: true
+        cpu: true
+        memory: true
+    - search:
+        provider: duckduckgo
+        target: _blank
+    ## Uncomment to enable Kubernetes integration
+    # - kubernetes:
+    #     cluster:
+    #       show: true
+    #       cpu: true
+    #       memory: true
+    #       showLabel: true
+    #       label: "cluster"
+    #     nodes:
+    #       show: true
+    #       cpu: true
+    #       memory: true
+    #       showLabel: true
+  kubernetes:
+    # change mode to 'cluster' to use RBAC service account
+    mode: disable
+  docker:
+  settings:
+
+persistence:
+  logs:
+    enabled: true
+    type: emptyDir
+    mountPath: /app/config/logs
+
+# resources:
+#   requests:
+#     memory: 10Mi
+#     cpu: 10m
+#   limits:
+#     memory: 200Mi
+#     cpu: 500m


### PR DESCRIPTION
## Proposed change

Moving my unofficial helm chart to the official repo. In addition to merging this, a new `gh-pages` branch needs to be created first which is where the resulting chart will be published to.

This is based on the official docs: https://helm.sh/docs/howto/chart_releaser_action/

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
