### PR TITLE
add prometheus service widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -521,5 +521,10 @@
     "pterodactyl": {
         "servers": "Servers",
         "nodes": "Nodes"
+    },
+    "prometheus": {
+        "targets_up": "Targets Up",
+        "targets_down": "Targets Down",
+        "targets_total": "Total Targets"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -75,6 +75,7 @@ const components = {
   xteve: dynamic(() => import("./xteve/component")),
   immich: dynamic(() => import("./immich/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),
+  prometheus: dynamic(() => import("./prometheus/component")),
 };
 
 export default components;

--- a/src/widgets/prometheus/component.jsx
+++ b/src/widgets/prometheus/component.jsx
@@ -1,0 +1,38 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+  const { data: targetsData, error: targetsError } = useWidgetAPI(widget, "targets");
+
+  if (targetsError) {
+    return <Container error={targetsError} />;
+  }
+
+  if (!targetsData) {
+    return (
+      <Container service={service}>
+        <Block label="prometheus.targets_up" />
+        <Block label="prometheus.targets_down" />
+        <Block label="prometheus.targets_total" />
+      </Container>
+    );
+  }
+
+  const upCount = targetsData.data.activeTargets.filter(a => a.health === "up").length;
+  const downCount = targetsData.data.activeTargets.filter(a => a.health === "down").length;
+  const totalCount = targetsData.data.activeTargets.length;
+
+  return (
+    <Container service={service}>
+      <Block label="prometheus.targets_up" value={t("common.number", { value: upCount })} />
+      <Block label="prometheus.targets_down" value={t("common.number", { value: downCount })} />
+      <Block label="prometheus.targets_total" value={t("common.number", { value: totalCount })} />
+    </Container>
+  );
+}

--- a/src/widgets/prometheus/widget.js
+++ b/src/widgets/prometheus/widget.js
@@ -6,7 +6,10 @@ const widget = {
 
   mappings: {
     targets: {
-      endpoint: "targets"
+      endpoint: "targets",
+      validate: [
+        "data"
+      ]
     },
   },
 };

--- a/src/widgets/prometheus/widget.js
+++ b/src/widgets/prometheus/widget.js
@@ -1,0 +1,14 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    targets: {
+      endpoint: "targets"
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -69,6 +69,7 @@ import xteve from "./xteve/widget";
 import immich from "./immich/widget";
 import uptimekuma from "./uptimekuma/widget";
 import unmanic from "./unmanic/widget";
+import prometheus from "./prometheus/widget";
 
 const widgets = {
   adguard,
@@ -144,6 +145,7 @@ const widgets = {
   xteve,
   immich,
   uptimekuma,
+  prometheus
 };
 
 export default widgets;


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

Adds a service widget for Prometheus to quickly see the health of targets.

![image](https://user-images.githubusercontent.com/9066520/221329930-39eaff5d-4d0d-4f74-a9a3-baca908dd646.png)
![image](https://user-images.githubusercontent.com/9066520/221330050-3d814e4f-d59e-47e7-b391-ad3f7b2961a9.png)

Based on the Targets api: https://prometheus.io/docs/prometheus/latest/querying/api/#targets

sample GET `/api/v1/targets`:
```JSON
{
  "status": "success",
  "data": {
    "activeTargets": [
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP:8080",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "cadvisor"
        },
        "labels": { "instance": "REDACTED_IP:8080", "job": "cadvisor" },
        "scrapePool": "cadvisor",
        "scrapeUrl": "http://REDACTED_IP:8080/metrics",
        "globalUrl": "http://REDACTED_IP:8080/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T02:00:13.484940363Z",
        "lastScrapeDuration": 0.095007963,
        "health": "up",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      },
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP:9617",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "pihole"
        },
        "labels": { "instance": "REDACTED_IP:9617", "job": "pihole" },
        "scrapePool": "pihole",
        "scrapeUrl": "http://REDACTED_IP:9617/metrics",
        "globalUrl": "http://REDACTED_IP:9617/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T02:00:18.802474142Z",
        "lastScrapeDuration": 0.005038828,
        "health": "up",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      },
      {
        "discoveredLabels": {
          "__address__": "localhost:9090",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "prometheus"
        },
        "labels": { "instance": "localhost:9090", "job": "prometheus" },
        "scrapePool": "prometheus",
        "scrapeUrl": "http://localhost:9090/metrics",
        "globalUrl": "http://prometheus:9090/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T02:00:13.875464073Z",
        "lastScrapeDuration": 0.005801555,
        "health": "up",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      },
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP",
          "__metrics_path__": "/pve",
          "__param_module": "default",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "pve"
        },
        "labels": { "instance": "REDACTED_IP", "job": "pve" },
        "scrapePool": "pve",
        "scrapeUrl": "http://REDACTED_IP:9221/pve?module=default\u0026target=REDACTED_IP",
        "globalUrl": "http://REDACTED_IP:9221/pve?module=default\u0026target=REDACTED_IP",
        "lastError": "Get \"http://REDACTED_IP:9221/pve?module=default\u0026target=REDACTED_IP\": dial tcp REDACTED_IP:9221: connect: connection refused",
        "lastScrape": "2023-02-25T02:00:21.54111235Z",
        "lastScrapeDuration": 0.000234303,
        "health": "down",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      },
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP:9798",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "1h",
          "__scrape_timeout__": "1m",
          "job": "speedtest"
        },
        "labels": { "instance": "REDACTED_IP:9798", "job": "speedtest" },
        "scrapePool": "speedtest",
        "scrapeUrl": "http://REDACTED_IP:9798/metrics",
        "globalUrl": "http://REDACTED_IP:9798/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T01:46:55.776200389Z",
        "lastScrapeDuration": 24.347487276,
        "health": "up",
        "scrapeInterval": "1h",
        "scrapeTimeout": "1m"
      },
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP:9167",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "unbound"
        },
        "labels": { "instance": "REDACTED_IP:9167", "job": "unbound" },
        "scrapePool": "unbound",
        "scrapeUrl": "http://REDACTED_IP:9167/metrics",
        "globalUrl": "http://REDACTED_IP:9167/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T02:00:16.102187625Z",
        "lastScrapeDuration": 0.012327259,
        "health": "up",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      },
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP:10100",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "ups"
        },
        "labels": { "instance": "REDACTED_IP:10100", "job": "ups" },
        "scrapePool": "ups",
        "scrapeUrl": "http://REDACTED_IP:10100/metrics",
        "globalUrl": "http://REDACTED_IP:10100/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T02:00:16.183778627Z",
        "lastScrapeDuration": 0.000509094,
        "health": "up",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      },
      {
        "discoveredLabels": {
          "__address__": "REDACTED_IP:10100",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "15s",
          "__scrape_timeout__": "10s",
          "job": "ups"
        },
        "labels": { "instance": "REDACTED_IP:10100", "job": "ups" },
        "scrapePool": "ups",
        "scrapeUrl": "http://REDACTED_IP:10100/metrics",
        "globalUrl": "http://REDACTED_IP:10100/metrics",
        "lastError": "",
        "lastScrape": "2023-02-25T02:00:15.920273366Z",
        "lastScrapeDuration": 0.000891047,
        "health": "up",
        "scrapeInterval": "15s",
        "scrapeTimeout": "10s"
      }
    ],
    "droppedTargets": []
  }
}
```

Sample usage:
```yaml
widget:
    type: prometheus
    url: http://prometheushost:port
```


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/44
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
