### PR TITLE
Change: Alter cloudflare widget to use api token [Breaking Change]

### DIFF
--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -44,8 +44,7 @@ export default async function credentialedProxyHandler(req, res, map) {
       } else if (widget.type === "miniflux") {
         headers["X-Auth-Token"] = `${widget.key}`;
       } else if (widget.type === "cloudflared") {
-        headers["X-Auth-Email"] = `${widget.email}`;
-        headers["X-Auth-Key"] = `${widget.key}`;
+        headers.Authorization = `Bearer ${widget.key}`;
       } else if (widget.type === "pterodactyl") {
         headers.Authorization = `Bearer ${widget.key}`;
       } else {


### PR DESCRIPTION
## Proposed change

This PR updates the cloudflare widget to use only an API token with minimal read permissions rather than the [deprecated] and overly-broad global API key. This is a breaking change, will be indicated as such in release notes. Of course I verified this still works and [updated docs](https://github.com/benphelps/homepage-docs/pull/42/commits/0646a54806d6a9a4ab19cee0a0f0c9e5fe65510f) accordingly.

<img width="501" alt="Screenshot 2023-02-26 at 8 13 39 AM" src="https://user-images.githubusercontent.com/4887959/221423068-c75d52aa-663f-4551-ab98-e3e63b565df2.png">

Closes #1060 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
