### PR TITLE
Add Quicklaunch feature to jump to a url

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -286,7 +286,9 @@
         "bookmark": "Bookmark",
         "service": "Service",
         "search": "Search",
-        "custom": "Custom"
+        "custom": "Custom",
+        "visit": "Visit",
+        "url": "URL"
     },
     "wmo": {
         "0-day": "Sunny",

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -265,7 +265,6 @@ function Home({ initialSettings }) {
             setSearchString={setSearchString}
             isOpen={searching}
             close={setSearching}
-            searchDescriptions={settings.quicklaunch?.searchDescriptions}
             searchProvider={settings.quicklaunch?.hideInternetSearch ? null : searchProvider}
           />
           {widgets && (


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

I wanted to be able to (quickly) open arbitrary URLs from Homepage.  This change adds some functionality to the quicklaunch feature so that users can input a url, ~~and then press SHIFT+ENTER to open the url.  The url will open in the window or tab corresponding to what the user has configured).  I've also added an indicator for this functionality so that a user knows when they are going to use the quicklaunch for a url.

Pressing enter while the shift button is pressed will open the url in the appropriate tab/window.~~

Edit: now
<img width="711" alt="Screenshot 2023-02-27 at 8 08 31 PM" src="https://user-images.githubusercontent.com/4887959/221751370-7b31055e-5727-4927-9370-f395fbc61ec9.png">


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
