### PR TITLE
Refactor Healthchecks widget API host to be parametrized

### DIFF
--- a/src/widgets/healthchecks/widget.js
+++ b/src/widgets/healthchecks/widget.js
@@ -1,7 +1,7 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
-  api: "https://healthchecks.io/api/v2/{endpoint}/{uuid}",
+  api: "{url}/api/v2/{endpoint}/{uuid}",
   proxyHandler: credentialedProxyHandler,
 
   mappings: {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

I have refactored the healthchecks widget so users are able to use locally hosted instances of healthchecks. This was done by simply replacing the hardcoded host with a URL parameter. 

**This technically breaks the previous version of the widget**, as users missing the URL parameter in the config will cause the widget to not work.  What would you recommend?

Request
https://github.com/benphelps/homepage/pull/1023#issuecomment-1446052950

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/47
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
