### PR TITLE
New Widget: Per Monitor Uptime Kuma Monitoring

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -469,6 +469,11 @@
         "incident": "Incident",
         "m": "m"
     },
+    "uptimekumamonitor": {
+        "up": "Up",
+        "down": "Down",
+        "maintenance": "Maintenance"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -74,6 +74,7 @@ const components = {
   unifi: dynamic(() => import("./unifi/component")),
   unmanic: dynamic(() => import("./unmanic/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),
+  uptimekumamonitor: dynamic(() => import("./uptimekumamonitor/component")),
   watchtower: dynamic(() => import("./watchtower/component")),
   xteve: dynamic(() => import("./xteve/component")),
 };

--- a/src/widgets/uptimekumamonitor/component.jsx
+++ b/src/widgets/uptimekumamonitor/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { widget } = service;
   const { data: isUp} = useWidgetAPI(widget);
   const { t } = useTranslation();
-
+  let upIndicator;
  
   if (!isUp) {
     return (
@@ -17,11 +17,10 @@ export default function Component({ service }) {
       </Container>
     );
   }
-  var upIndicator;
-  if (isUp.data.includes("Up")) {upIndicator = <span className="text-green-500">{t("uptimekumamonitor.up")}</span>}
-  else if (isUp.data.includes("Maintenance")) {upIndicator = <span style={{color: '#1747f5'}}>{t("uptimekumamonitor.maintenance")}</span>}
-  else if (isUp.data.includes("N/A")) {upIndicator = <span>{"N/A"}</span>}
-  else {upIndicator = <span className="text-red-500">{t("uptimekumamonitor.down")}</span>}
+  if (isUp.data.includes("Up")) upIndicator = <span className="text-green-500">{t("uptimekumamonitor.up")}</span>
+  else if (isUp.data.includes("Maintenance")) upIndicator = <span style={{color: '#1747f5'}}>{t("uptimekumamonitor.maintenance")}</span>
+  else if (isUp.data.includes("N/A")) upIndicator = <span>N/A</span>
+  else upIndicator = <span className="text-red-500">{t("uptimekumamonitor.down")}</span>
 
   return (
     <Container service={service}>

--- a/src/widgets/uptimekumamonitor/component.jsx
+++ b/src/widgets/uptimekumamonitor/component.jsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+  const { data: isUp} = useWidgetAPI(widget);
+  const { t } = useTranslation();
+
+ 
+  if (!isUp) {
+    return (
+      <Container service={service}>
+      <Block label="Status"/>
+      </Container>
+    );
+  }
+  var upIndicator;
+  if (isUp.data.includes("Up")) {upIndicator = <span className="text-green-500">{t("uptimekumamonitor.up")}</span>}
+  else if (isUp.data.includes("Maintenance")) {upIndicator = <span style={{color: '#1747f5'}}>{t("uptimekumamonitor.maintenance")}</span>}
+  else if (isUp.data.includes("N/A")) {upIndicator = <span>{"N/A"}</span>}
+  else {upIndicator = <span className="text-red-500">{t("uptimekumamonitor.down")}</span>}
+
+  return (
+    <Container service={service}>
+      <Block label="Status" value={upIndicator} />
+    </Container>
+  );
+}

--- a/src/widgets/uptimekumamonitor/proxy.js
+++ b/src/widgets/uptimekumamonitor/proxy.js
@@ -24,5 +24,5 @@ export default async function uptimekumamonitorProxyHandler(req, res) {
   };
   const [status, contentType, data] = await httpProxy(url, params);
   if (contentType) res.setHeader("Content-Type", contentType);
-  return res.status(200).json({data: data.toString()});
+  return res.status(status).json({data: data.toString()});
 }

--- a/src/widgets/uptimekumamonitor/proxy.js
+++ b/src/widgets/uptimekumamonitor/proxy.js
@@ -1,0 +1,28 @@
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+
+const logger = createLogger("uptimekumamonitorProxyHandler");
+
+export default async function uptimekumamonitorProxyHandler(req, res) {
+  const { group, service } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+  const widget = await getServiceWidget(group, service);
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+  const url = new URL(formatApiCall("{url}/api/badge/{monitor}/status", { ...widget }));
+  const params = { 
+    method: "GET", 
+    body: null
+  };
+  const [status, contentType, data] = await httpProxy(url, params);
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(200).json({data: data.toString()});
+}

--- a/src/widgets/uptimekumamonitor/widget.js
+++ b/src/widgets/uptimekumamonitor/widget.js
@@ -1,0 +1,7 @@
+import uptimekumamonitorProxyHandler from "./proxy";
+
+const widget = {
+    proxyHandler: uptimekumamonitorProxyHandler,
+}
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -68,6 +68,7 @@ import truenas from "./truenas/widget";
 import unifi from "./unifi/widget";
 import unmanic from "./unmanic/widget";
 import uptimekuma from "./uptimekuma/widget";
+import uptimekumamonitor from "./uptimekumamonitor/widget";
 import watchtower from "./watchtower/widget";
 import xteve from "./xteve/widget";
 
@@ -144,6 +145,7 @@ const widgets = {
   unifi_console: unifi,
   unmanic,
   uptimekuma,
+  uptimekumamonitor,
   watchtower,
   xteve,
 };


### PR DESCRIPTION
## Proposed change
![image](https://user-images.githubusercontent.com/34464552/222035984-ba2e4200-54e5-4d9f-9e5c-fa2a281e9f6c.png)
Adds a new uptime kuma widget that allows you to set specific monitors on a service by service basis. Similar to #1023 but with support for UptimeKuma

This is a continuation of #916, where this widget has a different approach of accessing a monitor's status without an API.

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/49
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

This is my first contribution to this project so if any additional information or work is needed, please let me know! I am also curious if it is possible in a service widget to add the 'healthy' banner (or the status dot from earlier versions of homepage) as a means to show status as opposed to a larger bar on the bottom.