### PR TITLE
Fix: use correct rate units for pyload

### DIFF
--- a/src/widgets/pyload/component.jsx
+++ b/src/widgets/pyload/component.jsx
@@ -26,7 +26,7 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="pyload.speed" value={t("common.bitrate", { value: pyloadData.speed })} />
+      <Block label="pyload.speed" value={t("common.byterate", { value: pyloadData.speed })} />
       <Block label="pyload.active" value={t("common.number", { value: pyloadData.active })} />
       <Block label="pyload.queue" value={t("common.number", { value: pyloadData.queue })} />
       <Block label="pyload.total" value={t("common.number", { value: pyloadData.total })} />


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

Closes #1077 

<img width="500" alt="Screenshot 2023-03-03 at 12 32 32 AM" src="https://user-images.githubusercontent.com/4887959/222671698-5d923999-62e6-4afe-acd2-19e0345c78e4.png">

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
