### PR TITLE
Fix: Use human readable units for storage in Immich widget

### DIFF
--- a/src/widgets/immich/component.jsx
+++ b/src/widgets/immich/component.jsx
@@ -1,8 +1,11 @@
+import { useTranslation } from "next-i18next";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
+  const { t } = useTranslation();
   const { widget } = service;
 
   const { data: immichData, error: immichError } = useWidgetAPI(widget);
@@ -27,7 +30,17 @@ export default function Component({ service }) {
       <Block label="immich.users" value={immichData.usageByUser.length} />
       <Block label="immich.photos" value={immichData.photos} />
       <Block label="immich.videos" value={immichData.videos} />
-      <Block label="immich.storage" value={immichData.usage} />
+      <Block label="immich.storage"
+        value={
+          // backwards-compatible e.g. '9 GiB'
+          immichData.usage.toString().toLowerCase().includes('b') ? 
+          immichData.usage : 
+          t("common.bytes", {
+            value: immichData.usage,
+            maximumFractionDigits: 1,
+            binary: true // match immich
+          })
+        } />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change
Immich updated its API endpoint to return raw bytes instead of human readable data. This PR adapts the existing code to take this into account.
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/22578704/224118838-a18b02ab-5629-4ed6-bc25-85271a1f89fa.png) | ![image](https://user-images.githubusercontent.com/22578704/224119144-f53f6dc3-35f3-4b9f-a5a0-466286744f7f.png) |

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
