### PR TITLE
Fix: Add padding to values in resources widget

### DIFF
--- a/src/components/widgets/resources/cpu.jsx
+++ b/src/components/widgets/resources/cpu.jsx
@@ -29,12 +29,12 @@ export default function Cpu({ expanded }) {
         <FiCpu className="text-theme-800 dark:text-theme-200 w-5 h-5" />
         <div className="flex flex-col ml-3 text-left min-w-[85px]">
           <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-            <div className="pl-0.5">-</div>
+            <div className="pl-0.5 pr-1">-</div>
             <div className="pr-1">{t("resources.cpu")}</div>
           </div>
           {expanded && (
             <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-              <div className="pl-0.5">-</div>
+              <div className="pl-0.5 pr-1">-</div>
               <div className="pr-1">{t("resources.load")}</div>
             </div>
           )}
@@ -51,7 +51,7 @@ export default function Cpu({ expanded }) {
       <FiCpu className="text-theme-800 dark:text-theme-200 w-5 h-5" />
       <div className="flex flex-col ml-3 text-left min-w-[85px]">
         <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-          <div className="pl-0.5">
+          <div className="pl-0.5 pr-1">
             {t("common.number", {
               value: data.cpu.usage,
               style: "unit",
@@ -63,7 +63,7 @@ export default function Cpu({ expanded }) {
         </div>
         {expanded && (
           <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-            <div className="pl-0.5">
+            <div className="pl-0.5 pr-1">
               {t("common.number", {
                 value: data.cpu.load,
                 maximumFractionDigits: 2,

--- a/src/components/widgets/resources/disk.jsx
+++ b/src/components/widgets/resources/disk.jsx
@@ -29,12 +29,12 @@ export default function Disk({ options, expanded }) {
         <FiHardDrive className="text-theme-800 dark:text-theme-200 w-5 h-5" />
         <div className="flex flex-col ml-3 text-left min-w-[85px]">
           <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-            <div className="pl-0.5">-</div>
+            <div className="pl-0.5 pr-1">-</div>
             <div className="pr-1">{t("resources.free")}</div>
           </span>
           {expanded && (
             <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-              <div className="pl-0.5">-</div>
+              <div className="pl-0.5 pr-1">-</div>
               <div className="pr-1">{t("resources.total")}</div>
             </span>
           )}
@@ -51,12 +51,12 @@ export default function Disk({ options, expanded }) {
       <FiHardDrive className="text-theme-800 dark:text-theme-200 w-5 h-5" />
       <div className="flex flex-col ml-3 text-left min-w-[85px]">
         <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-          <div className="pl-0.5">{t("common.bytes", { value: data.drive.freeGb * 1024 * 1024 * 1024 })}</div>
+          <div className="pl-0.5 pr-1">{t("common.bytes", { value: data.drive.freeGb * 1024 * 1024 * 1024 })}</div>
           <div className="pr-1">{t("resources.free")}</div>
         </span>
         {expanded && (
           <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-            <div className="pl-0.5">{t("common.bytes", { value: data.drive.totalGb * 1024 * 1024 * 1024 })}</div>
+            <div className="pl-0.5 pr-1">{t("common.bytes", { value: data.drive.totalGb * 1024 * 1024 * 1024 })}</div>
             <div className="pr-1">{t("resources.total")}</div>
           </span>
         )}

--- a/src/components/widgets/resources/memory.jsx
+++ b/src/components/widgets/resources/memory.jsx
@@ -29,12 +29,12 @@ export default function Memory({ expanded }) {
         <FaMemory className="text-theme-800 dark:text-theme-200 w-5 h-5" />
         <div className="flex flex-col ml-3 text-left min-w-[85px]">
           <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-            <div className="pl-0.5">-</div>
+            <div className="pl-0.5 pr-1">-</div>
             <div className="pr-1">{t("resources.free")}</div>
           </span>
           {expanded && (
             <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-              <div className="pl-0.5">-</div>
+              <div className="pl-0.5 pr-1">-</div>
               <div className="pr-1">{t("resources.total")}</div>
             </span>
           )}
@@ -51,14 +51,14 @@ export default function Memory({ expanded }) {
       <FaMemory className="text-theme-800 dark:text-theme-200 w-5 h-5" />
       <div className="flex flex-col ml-3 text-left min-w-[85px]">
         <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-          <div className="pl-0.5">
+          <div className="pl-0.5 pr-1">
             {t("common.bytes", { value: data.memory.freeMemMb * 1024 * 1024, maximumFractionDigits: 1, binary: true })}
           </div>
           <div className="pr-1">{t("resources.free")}</div>
         </span>
         {expanded && (
           <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-            <div className="pl-0.5">
+            <div className="pl-0.5 pr-1">
               {t("common.bytes", {
                 value: data.memory.totalMemMb * 1024 * 1024,
                 maximumFractionDigits: 1,


### PR DESCRIPTION
Closes #1110

## Proposed change

After:
<img width="431" alt="Screenshot 2023-03-15 at 10 26 20 AM" src="https://user-images.githubusercontent.com/4887959/225392020-fbde8789-efeb-49b8-8972-c8293ac816c6.png">

Current:
<img width="423" alt="Screenshot 2023-03-15 at 10 26 32 AM" src="https://user-images.githubusercontent.com/4887959/225392075-f0449293-0fdb-4cbb-b374-f485e2620f54.png">

Closes #1110 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
