### PR TITLE
Add support of NC-Token to Nextcloud widget

### DIFF
--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -49,11 +49,9 @@ export default async function credentialedProxyHandler(req, res, map) {
       } else if (widget.type === "miniflux") {
         headers["X-Auth-Token"] = `${widget.key}`;
       } else if (widget.type === "nextcloud") {
-        if ('key' in widget) {
-          logger.debug("Setting nextcloud to use NC-Token");
+        if (widget.key) {
           headers["NC-Token"] = `${widget.key}`;
         } else {
-          logger.debug("Setting nextcloud to use username", widget.username);
           headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
         }
       } else {

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -48,6 +48,14 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `Token ${widget.key}`;
       } else if (widget.type === "miniflux") {
         headers["X-Auth-Token"] = `${widget.key}`;
+      } else if (widget.type === "nextcloud") {
+        if ('key' in widget) {
+          logger.debug("Setting nextcloud to use NC-Token");
+          headers["NC-Token"] = `${widget.key}`;
+        } else {
+          logger.debug("Setting nextcloud to use username", widget.username);
+          headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
+        }
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/nextcloud/widget.js
+++ b/src/widgets/nextcloud/widget.js
@@ -1,8 +1,8 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/{endpoint}",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
 
   mappings: {
     serverinfo: {


### PR DESCRIPTION
## Proposed change

Adds support for Nextcloud's NC-Token authentication. This is safer than user+pass, as the only purpose of this token is to access the serverinfo endpoint, AFAIK.
<img width="646" alt="image" src="https://user-images.githubusercontent.com/1536554/226219473-6d1de95c-7515-4601-bb39-cf8da453572b.png">

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

Closes #1122

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
https://github.com/benphelps/homepage-docs/pull/60
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
