### PR TITLE
Add whatsupdocker widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -540,5 +540,9 @@
         "gross_percent_today": "Today",
         "gross_percent_1y": "One year",
         "gross_percent_max": "All time"
+    },
+    "whatsupdocker": {
+        "monitoring": "Monitoring",
+        "updates": "Updates"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -77,6 +77,7 @@ const components = {
   unmanic: dynamic(() => import("./unmanic/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),
   watchtower: dynamic(() => import("./watchtower/component")),
+  whatsupdocker: dynamic(() => import("./whatsupdocker/component")),
   xteve: dynamic(() => import("./xteve/component")),
 };
 

--- a/src/widgets/whatsupdocker/component.jsx
+++ b/src/widgets/whatsupdocker/component.jsx
@@ -1,0 +1,32 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: containersData, error: containersError } = useWidgetAPI(widget, "containers");
+  
+  if (containersError) {
+    return <Container error={containersError} />;
+  }
+
+  if (!containersData) {
+    return (
+      <Container service={service}>
+        <Block label="whatsupdocker.monitoring" />
+        <Block label="whatsupdocker.updates" />
+      </Container>
+    );
+  }
+
+  const totalCount = containersData.length;
+  const updatesAvailable = containersData.filter(container => container.updateAvailable).length;
+
+  return (
+    <Container service={service}>
+      <Block label="whatsupdocker.monitoring" value={totalCount} />
+      <Block label="whatsupdocker.updates" value={updatesAvailable} />
+    </Container>
+  );
+}

--- a/src/widgets/whatsupdocker/widget.js
+++ b/src/widgets/whatsupdocker/widget.js
@@ -1,0 +1,14 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    containers: {
+      endpoint: "api/containers"
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -71,6 +71,7 @@ import unifi from "./unifi/widget";
 import unmanic from "./unmanic/widget";
 import uptimekuma from "./uptimekuma/widget";
 import watchtower from "./watchtower/widget";
+import whatsupdocker from "./whatsupdocker/widget";
 import xteve from "./xteve/widget";
 
 const widgets = {
@@ -149,6 +150,7 @@ const widgets = {
   unmanic,
   uptimekuma,
   watchtower,
+  whatsupdocker,
   xteve,
 };
 


### PR DESCRIPTION
## Proposed change
Adds a widget for Whats Up Docker, https://github.com/fmartinou/whats-up-docker, showing the amount of containers currently being monitored by WUD as well as how many have updates available

API available: https://fmartinou.github.io/whats-up-docker/#/api/container

Closes #1151 (issue)

## Type of change

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/64
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
