### PR TITLE
Display Docker container's used memory instead of total memory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "18-buster"
+			"VARIANT": "18-bullseye"
 		}
 	},
 	"customizations": {

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.pnpm-store
 
 # testing
 /coverage

--- a/src/widgets/docker/component.jsx
+++ b/src/widgets/docker/component.jsx
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { useTranslation } from "next-i18next";
 
-import calculateCPUPercent from "./stats-helpers";
+import { calculateCPUPercent, calculateUsedMemory } from "./stats-helpers";
 
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
@@ -47,7 +47,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="docker.cpu" value={t("common.percent", { value: calculateCPUPercent(statsData.stats) })} />
       {statsData.stats.memory_stats.usage && 
-        <Block label="docker.mem" value={t("common.bytes", { value: statsData.stats.memory_stats.usage })} />
+        <Block label="docker.mem" value={t("common.bytes", { value: calculateUsedMemory(statsData.stats) })} />
       }
       {network && (
         <>

--- a/src/widgets/docker/stats-helpers.js
+++ b/src/widgets/docker/stats-helpers.js
@@ -1,4 +1,4 @@
-export default function calculateCPUPercent(stats) {
+export function calculateCPUPercent(stats) {
   let cpuPercent = 0.0;
   const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - stats.precpu_stats.cpu_usage.total_usage;
   const systemDelta = stats.cpu_stats.system_cpu_usage - stats.precpu_stats.system_cpu_usage;
@@ -8,4 +8,8 @@ export default function calculateCPUPercent(stats) {
   }
 
   return Math.round(cpuPercent * 10) / 10;
+}
+
+export function calculateUsedMemory(stats) {
+  return stats.memory_stats.usage - stats.memory_stats.stats.cache
 }

--- a/src/widgets/docker/stats-helpers.js
+++ b/src/widgets/docker/stats-helpers.js
@@ -11,5 +11,5 @@ export function calculateCPUPercent(stats) {
 }
 
 export function calculateUsedMemory(stats) {
-  return stats.memory_stats.usage - stats.memory_stats.stats.cache
+  return stats.memory_stats.usage - (stats.memory_stats.stats.cache ?? 0)
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

Hi!
Current implementation of stats for Docker containers displays total memory including cache, which in some cases might be really off compared to currently used memory. 

This change aligns used memory calculation with formula provided in [Docker API docs](https://docs.docker.com/engine/api/v1.42/#tag/Container/operation/ContainerStats) (see `used_memory` formula)

Example:
I have a container which due to its nature caches a lot of memory, but does not use much in general (screen from Portainer):
<img width="654" alt="Screenshot 2023-03-28 at 19 38 26" src="https://user-images.githubusercontent.com/2934986/228324317-c6026686-5eaa-4a76-b974-9aa90641824f.png">

Before change: 

<img width="503" alt="Screenshot 2023-03-28 at 19 33 59" src="https://user-images.githubusercontent.com/2934986/228324374-2e9d09f9-39b5-4756-8f22-99728ffe2964.png">

After change:

<img width="494" alt="Screenshot 2023-03-28 at 19 37 18" src="https://user-images.githubusercontent.com/2934986/228324400-c222cd35-801d-4285-b04f-7211e1b97a0d.png">

I also took a liberty to bump base image in devcontainer to allow developing on ARM64-based machines. Microsoft started providing ARM64 images starting from bullseye.

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
