### PR TITLE
Feature: support for Docker TLS based connections

### DIFF
--- a/src/utils/config/docker.js
+++ b/src/utils/config/docker.js
@@ -27,10 +27,22 @@ export default function getDockerArguments(server) {
     }
 
     if (servers[server].host) {
-      return {
-        conn: { host: servers[server].host, port: servers[server].port || null },
+      const res ={
+        conn: { host: servers[server].host },
         swarm: !!servers[server].swarm,
-      };
+      }
+
+      if (servers[server].port){
+        res.conn.port = servers[server].port;
+      }
+
+      if (servers[server].tls){
+        res.conn.ca = readFileSync(path.join(process.cwd(), "config", servers[server].tls.caFile));
+        res.conn.cert = readFileSync(path.join(process.cwd(), "config", servers[server].tls.certFile));
+        res.conn.key = readFileSync(path.join(process.cwd(), "config", servers[server].tls.keyFile));
+      }
+
+      return res;
     }
 
     return servers[server];


### PR DESCRIPTION
## Proposed change

Adds the ability to use TLS key/cert to connect to remote docker instances, rather than only supporting plaintext HTTP connections.

Closes # (issue)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: benphelps/homepage-docs#65
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
