### PR TITLE
Initial scopes support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dockerode": "^3.3.4",
     "follow-redirects": "^1.15.2",
     "i18next": "^21.9.2",
+    "ipaddr.js": "^2.0.1",
     "js-yaml": "^4.1.0",
     "json-rpc-2.0": "^1.4.1",
     "memory-cache": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.2",
     "@kubernetes/client-node": "^0.17.1",
+    "@supercharge/request-ip": "^1.2.0",
     "classnames": "^2.3.2",
     "compare-versions": "^5.0.1",
     "dockerode": "^3.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ dependencies:
   i18next:
     specifier: ^21.9.2
     version: 21.10.0
+  ipaddr.js:
+    specifier: ^2.0.1
+    version: 2.0.1
   js-yaml:
     specifier: ^4.1.0
     version: 4.1.0
@@ -1922,6 +1925,11 @@ packages:
   /interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /ipaddr.js@2.0.1:
+    resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
+    engines: {node: '>= 10'}
     dev: false
 
   /is-arguments@1.1.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ dependencies:
   '@kubernetes/client-node':
     specifier: ^0.17.1
     version: 0.17.1
+  '@supercharge/request-ip':
+    specifier: ^1.2.0
+    version: 1.2.0
   classnames:
     specifier: ^2.3.2
     version: 2.3.2
@@ -400,6 +403,10 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
 
+  /@supercharge/request-ip@1.2.0:
+    resolution: {integrity: sha512-wlt6JW69MHqLY2M6Sm/jVyCojNRKq2CBvwH0Hbx24SFhDQQGkgEjeKxVutDxHSyrWixFaOSLXC27euzxijhyMQ==}
+    dev: false
+
   /@swc/helpers@0.4.11:
     resolution: {integrity: sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==}
     dependencies:
@@ -645,6 +652,7 @@ packages:
   /autoprefixer@10.4.14(postcss@8.4.21):
     resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
     engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -1221,6 +1229,7 @@ packages:
 
   /eslint-config-prettier@8.8.0(eslint@8.37.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -2374,6 +2383,7 @@ packages:
   /next@12.3.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-VcyMJUtLZBGzLKo3oMxrEF0stxh8HwuW976pAzlHhI3t8qJ4SROjCrSh1T24bhrbjw55wfZXAbXPGwPt5FLRfQ==}
     engines: {node: '>=12.22.0'}
+    hasBin: true
     peerDependencies:
       fibers: '>= 3.1.0'
       node-sass: ^6.0.0 || ^7.0.0
@@ -3229,6 +3239,7 @@ packages:
   /tailwindcss@3.3.0(postcss@8.4.21):
     resolution: {integrity: sha512-hOXlFx+YcklJ8kXiCAfk/FMyr4Pm9ck477G0m/us2344Vuj355IpoEDB5UmGAsSpTBmr+4ZhjzW04JuFXkb/fw==}
     engines: {node: '>=12.13.0'}
+    hasBin: true
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
@@ -3450,6 +3461,7 @@ packages:
 
   /update-browserslist-db@1.0.10(browserslist@4.21.5):
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:

--- a/src/utils/config/scope.js
+++ b/src/utils/config/scope.js
@@ -1,0 +1,83 @@
+import { getSettings } from "utils/config/config";
+
+function checkIPRange(ip, ipSpace) {
+  // Check if the given IP is in the ipSpace address space using
+  // CIDR notation. If ipSpace is a plain IPv4 we just compare them.
+  const ipSpaceParts = ipSpace.split("/");
+  if (ipSpaceParts.length === 1) {
+    if (ip === ipSpace) {
+      return true;
+    }
+  } else if (ipSpaceParts.length === 2) {
+    const ipParts = ip.split(".");
+    const ipNum = parseInt(ipParts[0], 10) * 256 * 256 * 256 + parseInt(ipParts[1], 10) * 256 * 256 + parseInt(ipParts[2], 10) * 256 + parseInt(ipParts[3], 10);
+    const ipSpaceNum = parseInt(ipSpaceParts[0].split(".")[0], 10) * 256 * 256 * 256 + parseInt(ipSpaceParts[0].split(".")[1], 10) * 256 * 256 + parseInt(ipSpaceParts[0].split(".")[2], 10) * 256 + parseInt(ipSpaceParts[0].split(".")[3], 10);
+    const mask = 32 - parseInt(ipSpaceParts[1], 10);
+    // eslint-disable-next-line no-bitwise
+    const maskNum = 0xffffffff << mask;
+    // eslint-disable-next-line no-bitwise
+    if ((ipNum & maskNum) === (ipSpaceNum & maskNum)) {
+      return true;
+    }
+  } else {
+    console.error("Invalid ipSpace: ", ipSpace);
+  }
+  return false;
+}
+
+function isRequestProxied(req) {
+  const settings = getSettings();
+  // Check if trustedproxies is set
+  const trustedProxies = settings?.trustedproxies;
+
+  // If trustedproxies is set, check if the client IP
+  // is in the trustedproxies address space using CIDR notation.
+  if (trustedProxies) {
+    // Get the connection IP and strip IPv6 from the hybrid IPv4-IPv6 socket
+    const ip = req.connection.remoteAddress.replace(/^.*:/, '');
+
+    for (let i = 0; i < trustedProxies.length; i += 1) {
+        const proxy = trustedProxies[i].trim();
+        const inRange = checkIPRange(ip, proxy);
+        if (inRange) {
+            return true;
+        }
+    }
+  }
+  return false;
+}
+
+export function getClientIP(req) {
+  // Check if the request is proxied
+  const proxied = isRequestProxied(req);
+  // If the request is proxied, get the forwarded IP address
+  // from the X-Real-IP header
+  const forwarded = req.headers["x-real-ip"];
+  // If not get the connection IP address
+  const ip = req.connection.remoteAddress.replace(/^.*:/, '');
+
+  // Conditionally return the forwarded IP address or the connection IP address
+  return proxied ? (forwarded || ip) : ip;
+}
+
+export function isInLocalScope(req) {
+  const settings = getSettings();
+  // Check if localscope is set
+  const localScope = settings?.localscope;
+
+  // If localscope is set, check if the client IP
+  // is in the localscope address space using CIDR notation.
+  if (localScope) {
+    const ip = getClientIP(req);
+
+    for (let i = 0; i < localScope.length; i += 1) {
+        const localIP = localScope[i].trim();
+        const inRange = checkIPRange(ip, localIP)
+        if (inRange) {
+          return true;
+      }
+    }
+  }
+  return false;
+}
+  

--- a/src/utils/config/scope.js
+++ b/src/utils/config/scope.js
@@ -20,7 +20,7 @@ function checkIPRange(ip, ipSpace) {
       return true;
     }
   } else {
-    console.error("Invalid ipSpace: ", ipSpace);
+    throw new Error(`Invalid ipSpace: ${ipSpace}`);
   }
   return false;
 }

--- a/src/utils/config/scope.js
+++ b/src/utils/config/scope.js
@@ -2,51 +2,46 @@ import { getClientIp } from "@supercharge/request-ip";
 
 import { getSettings } from "utils/config/config";
 
-function checkIPRange(ip, ipSpace) {
-  // Check if the given IP is in the ipSpace address space using
-  // CIDR notation. If ipSpace is a plain IPv4 we just compare them.
-  const ipSpaceParts = ipSpace.split("/");
-  if (ipSpaceParts.length === 1) {
-    if (ip === ipSpace) {
-      return true;
+const ipaddr = require("ipaddr.js");
+
+function checkSingleIPRange(ip, cidr) {
+  try {
+    const ipAddr = ipaddr.process(ip);
+    // If the CIDR is not in the format of x.x.x.x/y, we assume it is a single IP
+    if (!cidr.includes("/")) {
+      const cidrIP = ipaddr.process(cidr);
+      // If both are IPv6, we need to normalize the strings
+      if (ipAddr.kind() === "ipv6" && cidrIP.kind() === "ipv6") {
+        return (ipAddr.toNormalizedString() === cidrIP.toNormalizedString());
+      }
+      return ipAddr.toString() === cidrIP.toString();
     }
-  } else if (ipSpaceParts.length === 2) {
-    const ipParts = ip.split(".");
-    const ipNum = parseInt(ipParts[0], 10) * 256 * 256 * 256 + parseInt(ipParts[1], 10) * 256 * 256 + parseInt(ipParts[2], 10) * 256 + parseInt(ipParts[3], 10);
-    const ipSpaceNum = parseInt(ipSpaceParts[0].split(".")[0], 10) * 256 * 256 * 256 + parseInt(ipSpaceParts[0].split(".")[1], 10) * 256 * 256 + parseInt(ipSpaceParts[0].split(".")[2], 10) * 256 + parseInt(ipSpaceParts[0].split(".")[3], 10);
-    const mask = 32 - parseInt(ipSpaceParts[1], 10);
-    // eslint-disable-next-line no-bitwise
-    const maskNum = 0xffffffff << mask;
-    // eslint-disable-next-line no-bitwise
-    if ((ipNum & maskNum) === (ipSpaceNum & maskNum)) {
-      return true;
-    }
-  } else {
-    throw new Error(`Invalid ipSpace: ${ipSpace}`);
+    // Otherwise, we assume it is a CIDR range
+    const range = ipaddr.parseCIDR(cidr);
+    return ipAddr.match(range);
+  } catch (e) {
+    return false;
+  }
+}
+
+function checkIPRange(ip, range) {
+  if (typeof range === "string") {
+    return checkSingleIPRange(ip, range);
+  }
+  if (Array.isArray(range)) {
+    return range.find((cidr) => checkSingleIPRange(ip, cidr)) !== undefined;
   }
   return false;
 }
 
-function isRequestProxied(remoteAddress) {
+export function isRequestProxied(remoteAddress) {
   const settings = getSettings();
   // Check if trustedproxies is set
   const trustedProxies = settings?.trustedproxies;
 
   // If trustedproxies is set, check if the client IP
-  // is in the trustedproxies address space using CIDR notation.
-  if (trustedProxies) {
-    // Get the connection IP and strip IPv6 from the hybrid IPv4-IPv6 socket
-    const ip = remoteAddress.replace(/^.*:/, '');
-
-    for (let i = 0; i < trustedProxies.length; i += 1) {
-        const proxy = trustedProxies[i].trim();
-        const inRange = checkIPRange(ip, proxy);
-        if (inRange) {
-            return true;
-        }
-    }
-  }
-  return false;
+  // is in the trustedproxies address space.
+  return trustedProxies ? checkIPRange(remoteAddress, trustedProxies) : false;
 }
 
 export function getRealClientIP(req) {
@@ -63,17 +58,10 @@ export function isInLocalScope(req) {
   const localScope = settings?.localscope;
 
   // If localscope is set, check if the client IP
-  // is in the localscope address space using CIDR notation.
+  // is in the localscope address space.
   if (localScope) {
     const ip = getRealClientIP(req);
-
-    for (let i = 0; i < localScope.length; i += 1) {
-        const localIP = localScope[i].trim();
-        const inRange = checkIPRange(ip, localIP)
-        if (inRange) {
-          return true;
-      }
-    }
+    return checkIPRange(ip, localScope);
   }
   return false;
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->
Here is a proposal (partially tracked by issue #1136) for implementing scopes. At present, it adds a way to identify whether a user is accessing from a local or remote scope, so that we can restrict or hide certain features such as system information, widgets, or services in the future. This proposal introduces two new configuration entries: "trustedproxies" and "localscope".
The "trustedproxies" entry contains an array of IP addresses or IP ranges. If a connection is made from any of these addresses, we assume that it is safe to extract the real user IP from the "x-real-ip" header.
The "localscope" entry contains an array of IP addresses or IP ranges. If a connection is made from any of these addresses, we consider the user to be in the local scope.

Example:
```
trustedproxies: [127.0.0.1, 192.168.1.0/24]
localscope: [192.168.1.0/24]
```

Please let me know if you have any feedback on this proposal so that we can move forward into supporting scopes.

Related to #1136 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
