### PR TITLE
Feature: Add Traefik IngressRoute support for Kubernetes

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -4,7 +4,7 @@ import path from "path";
 import yaml from "js-yaml";
 import Docker from "dockerode";
 import * as shvl from "shvl";
-import { NetworkingV1Api } from "@kubernetes/client-node";
+import { CustomObjectsApi, NetworkingV1Api } from "@kubernetes/client-node";
 
 import createLogger from "utils/logger";
 import checkAndCopyConfig, { substituteEnvironmentVars } from "utils/config/config";
@@ -145,6 +145,7 @@ export async function servicesFromKubernetes() {
       return [];
     }
     const networking = kc.makeApiClient(NetworkingV1Api);
+    const crd = kc.makeApiClient(CustomObjectsApi);
 
     const ingressList = await networking.listIngressForAllNamespaces(null, null, null, null)
       .then((response) => response.body)
@@ -152,6 +153,20 @@ export async function servicesFromKubernetes() {
         logger.error("Error getting ingresses: %d %s %s", error.statusCode, error.body, error.response);
         return null;
       });
+
+     const traefikIngressList = await crd.listClusterCustomObject("traefik.containo.us", "v1alpha1", "ingressroutes")
+      .then((response) => response.body)
+      .catch((error) => {
+        logger.error("Error getting traefik ingresses: %d %s %s", error.statusCode, error.body, error.response);
+        return null;
+      });
+
+    if (traefikIngressList && traefikIngressList.items.length > 0) {
+      const traefikServices = traefikIngressList.items
+      .filter((ingress) => ingress.metadata.annotations && ingress.metadata.annotations[`${ANNOTATION_BASE}/href`])
+      ingressList.items.push(...traefikServices);
+    }
+    
     if (!ingressList) {
       return [];
     }


### PR DESCRIPTION
## Proposed change

*Please excuse the duplicate PR, I messed up the last one!*

This adds support for Traefik IngressRoute CRDs as well as the traditional Kubernetes Ingress manifest.

A check for Traefik IngressRoute objects is carried out and if found, will then check for the `href` attribute set in annotations. If found, it will push the IngressRoute object into the existing `ingressList.items` array.

The reason for the `href` requirement is the matching rule that IngressRoute can be tricky to parse, and it seems better to rely on the user to set it. If it is not set, it will not be added to the `ingressList` for later processing.

A log error has been added for failing to find IngressRoute objects, but this could be only set via an additional Homepage setting.

Closes #906

Documentation PR: https://github.com/benphelps/homepage-docs/pull/69

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
