### PR TITLE
Add option to specify volume in Diskstation widget

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -249,7 +249,8 @@ export function cleanServiceGroups(groups) {
           podSelector,
           wan, // opnsense widget,
           enableBlocks, // emby/jellyfin
-          enableNowPlaying
+          enableNowPlaying,
+          volume // diskstation widget
         } = cleanedService.widget;
 
         const fieldsList = typeof fields === 'string' ? JSON.parse(fields) : fields;
@@ -283,6 +284,9 @@ export function cleanServiceGroups(groups) {
         if (type === "emby" || type === "jellyfin") {
           if (enableBlocks) cleanedService.widget.enableBlocks = enableBlocks === 'true';
           if (enableNowPlaying) cleanedService.widget.enableNowPlaying = enableNowPlaying === 'true';
+        }
+        if (type === "diskstation") {
+          if (volume) cleanedService.widget.volume = volume;
         }
       }
 

--- a/src/widgets/diskstation/component.jsx
+++ b/src/widgets/diskstation/component.jsx
@@ -33,16 +33,7 @@ export default function Component({ service }) {
   const uptime = `${ t("common.number", { value: days }) } ${ t("diskstation.days") }`;
 
   // storage info
-  const volumeName = widget.volume;
-
-  let volume;
-
-  if (volumeName) {
-    volume = storageData.data.vol_info?.find(vol => vol.name === volumeName) 
-  } else {
-    volume = storageData.data.vol_info?.[0];
-  }
-
+  const volume = widget.volume ? storageData.data.vol_info?.find(vol => vol.name === widget.volume) : storageData.data.vol_info?.[0];
   const usedBytes = parseFloat(volume?.used_size);
   const totalBytes = parseFloat(volume?.total_size);
   const freeBytes = totalBytes - usedBytes;

--- a/src/widgets/diskstation/component.jsx
+++ b/src/widgets/diskstation/component.jsx
@@ -33,8 +33,16 @@ export default function Component({ service }) {
   const uptime = `${ t("common.number", { value: days }) } ${ t("diskstation.days") }`;
 
   // storage info
-  // TODO: figure out how to display info for more than one volume
-  const volume = storageData.data.vol_info?.[0];
+  const volumeName = widget.volume;
+
+  let volume;
+
+  if (volumeName) {
+    volume = storageData.data.vol_info?.find(vol => vol.name === volumeName) 
+  } else {
+    volume = storageData.data.vol_info?.[0];
+  }
+
   const usedBytes = parseFloat(volume?.used_size);
   const totalBytes = parseFloat(volume?.total_size);
   const freeBytes = totalBytes - usedBytes;


### PR DESCRIPTION
## Proposed change

Implements proposal I made in https://github.com/benphelps/homepage/issues/1167. Allows user to specify which volume's free space to display on Diskstation widget

The change is backwards compatible, if user does not specify volume, then first volume from the list will be displayed.

Closes #1167

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/67
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
