### PR TITLE
True fix for settings revert after container creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY . .
 
 SHELL ["/bin/ash", "-xeo", "pipefail", "-c"]
 RUN npm run telemetry \
- && mkdir config && echo '---' > config/settings.yaml \
+ && mkdir config \
  && NEXT_PUBLIC_BUILDTIME=$BUILDTIME NEXT_PUBLIC_VERSION=$VERSION NEXT_PUBLIC_REVISION=$REVISION npm run build
 
 # Production image, copy all the files and run next

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,8 @@ export PGID=${PGID:-0}
 # while also supporting the lscr.io /config directory
 [ ! -d "/app/config" ] && ln -s /config /app/config
 
+export HOMEPAGE_BUILDTIME=$(date +%s)
+
 # Set privileges for /app but only if pid 1 user is root and we are dropping privileges.
 # If container is run as an unprivileged user, it means owner already handled ownership setup on their own.
 # Running chown in that case (as non-root) will cause error

--- a/src/pages/api/hash.js
+++ b/src/pages/api/hash.js
@@ -19,8 +19,8 @@ export default async function handler(req, res) {
     return hash(readFileSync(configYaml, "utf8"));
   });
 
-  // this ties hash to specific build which should force revaliation between versions
-  const buildTime = process.env.NEXT_PUBLIC_BUILDTIME?.length ? process.env.NEXT_PUBLIC_BUILDTIME : '';
+  // set to date by docker entrypoint, will force revalidation between restarts/recreates
+  const buildTime = process.env.HOMEPAGE_BUILDTIME?.length ? process.env.HOMEPAGE_BUILDTIME : '';
 
   const combinedHash = hash(hashes.join("") + buildTime);
 

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { join } from "path";
-import { existsSync, copyFile, readFileSync } from "fs";
+import { existsSync, readFileSync, copyFileSync } from "fs";
 
 import cache from "memory-cache";
 import yaml from "js-yaml";
@@ -13,13 +13,13 @@ export default function checkAndCopyConfig(config) {
   const configYaml = join(process.cwd(), "config", config);
   if (!existsSync(configYaml)) {
     const configSkeleton = join(process.cwd(), "src", "skeleton", config);
-    copyFile(configSkeleton, configYaml, (err) => {
-      if (err) {
+    try {
+      copyFileSync(configSkeleton, configYaml)
+      console.info("%s was copied to the config folder", config);
+    } catch (err) {
         console.error("error copying config", err);
         throw err;
-      }
-      console.info("%s was copied to the config folder", config);
-    });
+    }
 
     return true;
   }


### PR DESCRIPTION
## Proposed change

Perhaps just needed some time to meditate on this but I think this is a true solution here. Using similar logic from #963, this PR inserts a timestamp into the hash which gets set by docker-entrypoint.sh i.e. on container start. The only real downside of this that I can think of is that revalidate will happen even when the container is _restarted_ not just _re-created_, but actually... that seems totally acceptable =)

There's another (not really directly related) change in here just to make settings.yaml creation consistent with others

Fixes #576 , like for reals

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
