### PR TITLE
Feature: Global & per-service docker stats control

### DIFF
--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -14,7 +14,8 @@ import ResolvedIcon from "components/resolvedicon";
 export default function Item({ service }) {
   const hasLink = service.href && service.href !== "#";
   const { settings } = useContext(SettingsContext);
-  const [statsOpen, setStatsOpen] = useState(false);
+  const showStats = (service.showStats === false) ? false : settings.showStats;
+  const [statsOpen, setStatsOpen] = useState(service.showStats);
   const [statsClosing, setStatsClosing] = useState(false);
 
   // set stats to closed after 300ms
@@ -107,21 +108,21 @@ export default function Item({ service }) {
         {service.container && service.server && (
           <div
             className={classNames(
-              settings.showStats || (statsOpen && !statsClosing) ? "max-h-[110px] opacity-100" : " max-h-[0] opacity-0",
+              showStats || (statsOpen && !statsClosing) ? "max-h-[110px] opacity-100" : " max-h-[0] opacity-0",
               "w-full overflow-hidden transition-all duration-300 ease-in-out"
             )}
           >
-            {(settings.showStats || statsOpen) && <Docker service={{ widget: { container: service.container, server: service.server } }} />}
+            {(showStats || statsOpen) && <Docker service={{ widget: { container: service.container, server: service.server } }} />}
           </div>
         )}
         {service.app && (
           <div
             className={classNames(
-              settings.showStats || (statsOpen && !statsClosing) ? "max-h-[55px] opacity-100" : " max-h-[0] opacity-0",
+              showStats || (statsOpen && !statsClosing) ? "max-h-[55px] opacity-100" : " max-h-[0] opacity-0",
               "w-full overflow-hidden transition-all duration-300 ease-in-out"
             )}
           >
-            {(settings.showStats || statsOpen) && <Kubernetes service={{ widget: { namespace: service.namespace, app: service.app, podSelector: service.podSelector } }} />}
+            {(showStats || statsOpen) && <Kubernetes service={{ widget: { namespace: service.namespace, app: service.app, podSelector: service.podSelector } }} />}
           </div>
         )}
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -236,6 +236,7 @@ export function cleanServiceGroups(groups) {
     name: serviceGroup.name,
     services: serviceGroup.services.map((service) => {
       const cleanedService = { ...service };
+      if (cleanedService.showStats !== undefined) cleanedService.showStats = JSON.parse(cleanedService.showStats);
       if (typeof service.weight === 'string') {
         const weight = parseInt(service.weight, 10);
         if (Number.isNaN(weight)) {


### PR DESCRIPTION
## Proposed change

Combined with https://github.com/benphelps/homepage/commit/7aa496f66f0962495c98a1a3ee0814f835d985aa this PR allows expanding docker stats globally with (`showStats: true` in settings.yaml) or per-service (with `showStats: true` in the service config). In my testing theres a delay for the stats but not an unreasonable one and with anything like this its users-choice.

Closes #390

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/70
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
