### PR TITLE
Fix: Glances include cpu tempts labeled `Tctl`

### DIFF
--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -6,7 +6,7 @@ import { useTranslation } from "next-i18next";
 
 import UsageBar from "../resources/usage-bar";
 
-const cpuSensorLabels = ["cpu_thermal", "Core"];
+const cpuSensorLabels = ["cpu_thermal", "Core", "Tctl"];
 
 function convertToFahrenheit(t) {
   return t * 9/5 + 32


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

See API output from linked issue, PR is to include sensors labeled "Tctl"

<img width="122" alt="Screenshot 2023-04-18 at 12 10 06 PM" src="https://user-images.githubusercontent.com/4887959/232880715-ecc61eb1-919f-402e-89dc-e48aa7e562b5.png">

Closes #1375

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
