### PR TITLE
Feature: support blur, saturation & brightness filters for background images

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -318,15 +318,26 @@ function Home({ initialSettings }) {
 
 export default function Wrapper({ initialSettings, fallback }) {
   const wrappedStyle = {};
+  let backgroundBlur = false;
+  let backgroundSaturate = false;
+  let backgroundBrightness = false;
   if (initialSettings && initialSettings.background) {
-    const opacity = initialSettings.backgroundOpacity ?? 1;
+    let opacity = initialSettings.backgroundOpacity ?? 1;
+    let backgroundImage = initialSettings.background;
+    if (typeof initialSettings.background === 'object') {
+      backgroundImage = initialSettings.background.image;
+      backgroundBlur = initialSettings.background.blur !== undefined;
+      backgroundSaturate = initialSettings.background.saturate !== undefined;
+      backgroundBrightness = initialSettings.background.brightness !== undefined;
+      if (initialSettings.background.opacity !== undefined) opacity = initialSettings.background.opacity / 100;
+    }
     const opacityValue = 1 - opacity;
     wrappedStyle.backgroundImage = `
       linear-gradient(
         rgb(var(--bg-color) / ${opacityValue}),
         rgb(var(--bg-color) / ${opacityValue})
       ),
-      url(${initialSettings.background})`;
+      url(${backgroundImage})`;
     wrappedStyle.backgroundPosition = "center";
     wrappedStyle.backgroundSize = "cover";
   }
@@ -345,7 +356,15 @@ export default function Wrapper({ initialSettings, fallback }) {
         className="fixed overflow-auto w-full h-full bg-theme-50 dark:bg-theme-800 transition-all"
         style={wrappedStyle}
       >
-        <Index initialSettings={initialSettings} fallback={fallback} />
+        <div
+        id="inner_wrapper" 
+        className={classNames(
+          backgroundBlur && `backdrop-blur${initialSettings.background.blur.length ? '-' : ""}${initialSettings.background.blur}`,
+          backgroundSaturate && `backdrop-saturate-${initialSettings.background.saturate}`,
+          backgroundBrightness && `backdrop-brightness-${initialSettings.background.brightness}`,
+        )}>
+          <Index initialSettings={initialSettings} fallback={fallback} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Proposed change

I like this idea to allow more customization of background images, this is of course backwards compatible but can now specify:

```yaml
background: 
  image: https://images.unsplash.com/photo-1681802731183-c07ee779dabd
  blur: sm # sm, "", md... see https://tailwindcss.com/docs/backdrop-blur
  saturate: 50 # 0, 50, 100... see https://tailwindcss.com/docs/backdrop-saturate
  brightness: 50 # 0, 50, 75... see https://tailwindcss.com/docs/backdrop-brightness
  opacity: 50 # 0-100
```

yields :
<img width="1726" alt="Screenshot 2023-04-18 at 10 49 48 PM" src="https://user-images.githubusercontent.com/4887959/232979651-46c171f6-338d-4a08-8f97-eb6f3a1d9e31.png">

Closes #1378

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/77
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
