### PR TITLE
Allow setting rpcUrl path for Transmission widget

### DIFF
--- a/src/widgets/transmission/proxy.js
+++ b/src/widgets/transmission/proxy.js
@@ -33,7 +33,9 @@ export default async function transmissionProxyHandler(req, res) {
     cache.put(`${headerCacheKey}.${service}`, headers);
   }
 
-  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+  const api = `${widget.url}${widget.rpcUrl || widgets[widget.type].rpcUrl}rpc`;
+
+  const url = new URL(formatApiCall(api, { endpoint, ...widget }));
   const csrfHeaderName = "x-transmission-session-id";
 
   const method = "POST";

--- a/src/widgets/transmission/widget.js
+++ b/src/widgets/transmission/widget.js
@@ -1,7 +1,7 @@
 import transmissionProxyHandler from "./proxy";
 
 const widget = {
-  api: "{url}/transmission/rpc",
+  rpcUrl: "/transmission/",
   proxyHandler: transmissionProxyHandler,
 };
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->
[Transmission allows setting the RPC url path](https://github.com/transmission/transmission/blob/e68c72daa479f81d519fb83219aedc81d1516fb9/docs/Editing-Configuration-Files.md#L128) to something other than the default `/transmission/`. Changing this value can be necessary when doing some types of routing (e.g. `transmission.custom-domain.com`) to get the web front end to function properly.

The Transmission widget in Homepage hardcodes the value to the default and doesn't allow modifying it. This small refactor creates an `rpcUrl` optional prop on the Transmission widget that can be set to the same value as the `rpc-url` value in your Transmission `settings.json` file. If unset, the widget will use the default value of `/transmission/`.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/81
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
