### PR TITLE
Fix: quick launch services show as bookmarks

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -32,6 +32,7 @@ export async function servicesFromConfig() {
     services: servicesGroup[Object.keys(servicesGroup)[0]].map((entries) => ({
       name: Object.keys(entries)[0],
       ...entries[Object.keys(entries)[0]],
+      type: 'service'
     })),
   }));
 
@@ -82,6 +83,7 @@ export async function servicesFromDocker() {
                 constructedService = {
                   container: container.Names[0].replace(/^\//, ""),
                   server: serverName,
+                  type: 'service'
                 };
               }
               shvl.set(constructedService, label.replace("homepage.", ""), container.Labels[label]);
@@ -183,6 +185,7 @@ export async function servicesFromKubernetes() {
         icon: ingress.metadata.annotations[`${ANNOTATION_BASE}/icon`] || '',
         description: ingress.metadata.annotations[`${ANNOTATION_BASE}/description`] || '',
         external: false,
+        type: 'service'
       };
       if (ingress.metadata.annotations[`${ANNOTATION_BASE}/external`]) {
         constructedService.external = String(ingress.metadata.annotations[`${ANNOTATION_BASE}/external`]).toLowerCase() === "true"


### PR DESCRIPTION
## Proposed change

I swore I fixed this already then it broke again...

Closes #1395 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
