### PR TITLE
force icons to fit withing a 32x32 square

### DIFF
--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -3,7 +3,19 @@ import Image from "next/future/image";
 export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "logo" }) {
   // direct or relative URLs
   if (icon.startsWith("http") || icon.startsWith("/")) {
-    return <Image src={`${icon}`} width={width} height={height} alt={alt} />;
+    return (
+      <Image
+        src={`${icon}`}
+        width={width}
+        height={height}
+        style={{
+          width,
+          height,
+          objectFit: "contain",
+        }}
+        alt={alt}
+      />
+    );
   }
 
   // mdi- prefixed, material design icons
@@ -31,6 +43,11 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
       src={`https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/${iconName}.png`}
       width={width}
       height={height}
+      style={{
+        width,
+        height,
+        objectFit: "contain",
+      }}
       alt={alt}
     />
   );


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

Closes #1404 

This adjusts the CSS for icons to ensure that if they are taller than they are wide, they are constrained to a 32x32 icon

Before:

![before](https://i.imgur.com/2ItkB5m.png)

After:

![after](https://i.imgur.com/8RWNuq3.png)


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
