### PR TITLE
Feature: add albums to Plex service widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -132,6 +132,7 @@
     },
     "plex": {
         "streams": "Active Streams",
+        "albums": "Albums",
         "movies": "Movies",
         "tv": "TV Shows"
     },

--- a/src/widgets/plex/component.jsx
+++ b/src/widgets/plex/component.jsx
@@ -21,6 +21,7 @@ export default function Component({ service }) {
     return (
       <Container service={service}>
         <Block label="plex.streams" />
+        <Block label="plex.albums" />
         <Block label="plex.movies" />
         <Block label="plex.tv" />
       </Container>
@@ -30,6 +31,7 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="plex.streams" value={t("common.number", { value: plexData.streams })} />
+      <Block label="plex.albums" value={t("common.number", { value: plexData.albums })} />
       <Block label="plex.movies" value={t("common.number", { value: plexData.movies })} />
       <Block label="plex.tv" value={t("common.number", { value: plexData.tv })} />
     </Container>

--- a/src/widgets/plex/proxy.js
+++ b/src/widgets/plex/proxy.js
@@ -10,6 +10,7 @@ import widgets from "widgets/widgets";
 
 const proxyName = "plexProxyHandler";
 const librariesCacheKey = `${proxyName}__libraries`;
+const albumsCacheKey = `${proxyName}__albums`;
 const moviesCacheKey = `${proxyName}__movies`;
 const tvCacheKey = `${proxyName}__tv`;
 const logger = createLogger(proxyName);
@@ -87,9 +88,20 @@ export default async function plexProxyHandler(req, res) {
     }
   }
 
+  let albums = cache.get(`${albumsCacheKey}.${service}`);
   let movies = cache.get(`${moviesCacheKey}.${service}`);
   let tv = cache.get(`${tvCacheKey}.${service}`);
-  if (movies === null || tv === null) {
+  if (albums === null || movies === null || tv === null) {
+    albums = 0;
+    logger.debug("Getting album counts from Plex API");
+    const albumLibraries = libraries.filter(l => ["artist"].includes(l._attributes.type));
+    await Promise.all(albumLibraries.map(async (library) => {
+      [status, apiData] = await fetchFromPlexAPI(`/library/sections/${library._attributes.key}/albums`, widget);
+      if (apiData && apiData.MediaContainer) {
+        const size = parseInt(apiData.MediaContainer._attributes.size, 10);
+        albums += size;
+      }
+    }));
     movies = 0;
     tv = 0;
     logger.debug("Getting movie + tv counts from Plex API");
@@ -105,14 +117,16 @@ export default async function plexProxyHandler(req, res) {
         }
       }
     }));
+    cache.put(`${albumsCacheKey}.${service}`, albums, 1000 * 60 * 10);
     cache.put(`${tvCacheKey}.${service}`, tv, 1000 * 60 * 10);
     cache.put(`${moviesCacheKey}.${service}`, movies, 1000 * 60 * 10);
   }
   
   const data = {
     streams,
+    albums,
+    movies,
     tv,
-    movies
   };
 
   return res.status(status).send(data);

--- a/src/widgets/plex/proxy.js
+++ b/src/widgets/plex/proxy.js
@@ -93,27 +93,23 @@ export default async function plexProxyHandler(req, res) {
   let tv = cache.get(`${tvCacheKey}.${service}`);
   if (albums === null || movies === null || tv === null) {
     albums = 0;
-    logger.debug("Getting album counts from Plex API");
-    const albumLibraries = libraries.filter(l => ["artist"].includes(l._attributes.type));
-    await Promise.all(albumLibraries.map(async (library) => {
-      [status, apiData] = await fetchFromPlexAPI(`/library/sections/${library._attributes.key}/albums`, widget);
-      if (apiData && apiData.MediaContainer) {
-        const size = parseInt(apiData.MediaContainer._attributes.size, 10);
-        albums += size;
-      }
-    }));
     movies = 0;
     tv = 0;
-    logger.debug("Getting movie + tv counts from Plex API");
-    const movieTVLibraries = libraries.filter(l => ["movie", "show"].includes(l._attributes.type));
+    logger.debug("Getting counts from Plex API");
+    const movieTVLibraries = libraries.filter(l => ["movie", "show", "artist"].includes(l._attributes.type));
     await Promise.all(movieTVLibraries.map(async (library) => {
-      [status, apiData] = await fetchFromPlexAPI(`/library/sections/${library._attributes.key}/all`, widget);
+      const libraryURL = ["movie", "show"].includes(library._attributes.type) ? 
+        `/library/sections/${library._attributes.key}/all` : // tv + movies
+        `/library/sections/${library._attributes.key}/albums`; // music
+      [status, apiData] = await fetchFromPlexAPI(libraryURL, widget);
       if (apiData && apiData.MediaContainer) {
         const size = parseInt(apiData.MediaContainer._attributes.size, 10);
         if (library._attributes.type === "movie") {
           movies += size;
         } else if (library._attributes.type === "show") {
           tv += size;
+        } else if (library._attributes.type === "artist") {
+          albums += size;
         }
       }
     }));


### PR DESCRIPTION
## Proposed change

With this change album count of the music library of Plex is added to Plex widget...

![imatge](https://user-images.githubusercontent.com/13131391/234806242-b3392475-cc4b-45e2-b070-a4c36e46e87c.png)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
