### PR TITLE
Fix: align services and widgets

### DIFF
--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -34,7 +34,7 @@ export default function Item({ service }) {
       <div
         className={`${
           hasLink ? "cursor-pointer " : " "
-        }transition-all h-15 mb-3 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative`}
+        }transition-all h-15 mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative`}
       >
         <div className="flex select-none">
           {service.icon &&


### PR DESCRIPTION
## Proposed change

Fix misalignment of services and widgets...

Before: ![imatge](https://user-images.githubusercontent.com/13131391/234815885-46a89025-08fa-49ed-bb15-439711700764.png)

After: ![imatge](https://user-images.githubusercontent.com/13131391/234816365-90090197-dda7-4d70-99af-2d9955e72587.png)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
