### PR TITLE
Fix: ping unit display for speedtest widget

### DIFF
--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -35,7 +35,7 @@ export default function Ping({ service }) {
   
   return (
     <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden" title={statusText}>
-      <div className="text-[8px] font-bold text-emerald-500/80">{t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", unitDisplay: "narrow", maximumFractionDigits: 0 })}</div>
+      <div className="text-[8px] font-bold text-emerald-500/80">{t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })}</div>
     </div>
   );
 

--- a/src/widgets/speedtest/component.jsx
+++ b/src/widgets/speedtest/component.jsx
@@ -38,7 +38,6 @@ export default function Component({ service }) {
           value: speedtestData.data.ping,
           style: "unit",
           unit: "millisecond",
-          unitDisplay: "narrow",
         })}
       />
     </Container>


### PR DESCRIPTION
## Proposed change

IMO, "unit indicator" must be displayed in a separate mode from its "number" (maybe I'm very fussy)...

Before: ![imatge](https://user-images.githubusercontent.com/13131391/234847508-70861ede-1587-4050-9a47-9dcef91aa959.png)

After: ![imatge](https://user-images.githubusercontent.com/13131391/234847357-cad4425c-e7f3-4ca3-a41d-a73387cbc752.png)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
