### PR TITLE
Add setting to hide widgets on failure

### DIFF
--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -1,8 +1,18 @@
+import { useContext } from "react";
+
 import Error from "./error";
 
+import { SettingsContext } from "utils/contexts/settings";
+
 export default function Container({ error = false, children, service }) {
+  const { settings } = useContext(SettingsContext);
+
   if (error) {
-    return <Error error={error} />
+    if (settings.hideErrors || service.widget.hide_errors) {
+      return null;
+    }
+
+    return <Error service={service} error={error} />
   }
 
   let visibleChildren = children;

--- a/src/components/services/widget/error.jsx
+++ b/src/components/services/widget/error.jsx
@@ -9,12 +9,10 @@ function displayData(data) {
   return (data.type === 'Buffer') ? Buffer.from(data).toString() : JSON.stringify(data, 4);
 }
 
-export default function Error({ error }) {
+export default function Error({ error: err }) {
   const { t } = useTranslation();
 
-  if (error?.data?.error) {
-    error = error.data.error; // eslint-disable-line no-param-reassign
-  }
+  const { error } = err?.data ?? { error: err };
 
   return (
     <details className="px-1 pb-1">

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -257,6 +257,7 @@ export function cleanServiceGroups(groups) {
         const {
           type, // all widgets
           fields,
+          hideErrors,
           server, // docker widget
           container,
           currency, // coinmarketcap widget
@@ -269,7 +270,7 @@ export function cleanServiceGroups(groups) {
           wan, // opnsense widget,
           enableBlocks, // emby/jellyfin
           enableNowPlaying,
-          volume // diskstation widget
+          volume, // diskstation widget
         } = cleanedService.widget;
 
         const fieldsList = typeof fields === 'string' ? JSON.parse(fields) : fields;
@@ -277,6 +278,7 @@ export function cleanServiceGroups(groups) {
         cleanedService.widget = {
           type,
           fields: fieldsList || null,
+          hide_errors: hideErrors || false,
           service_name: service.name,
           service_group: serviceGroup.name,
         };

--- a/src/widgets/adguard/component.jsx
+++ b/src/widgets/adguard/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: adguardData, error: adguardError } = useWidgetAPI(widget, "stats");
 
   if (adguardError) {
-    return <Container error={adguardError} />;
+    return <Container service={service} error={adguardError} />;
   }
   
   if (!adguardData) {

--- a/src/widgets/audiobookshelf/component.jsx
+++ b/src/widgets/audiobookshelf/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
 
   
   if (librariesError) {
-    return <Container error={librariesError} />;
+    return <Container service={service} error={librariesError} />;
   }
   
   if (!librariesData) {

--- a/src/widgets/authentik/component.jsx
+++ b/src/widgets/authentik/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (usersError || loginsError || failedLoginsError) {
     const finalError = usersError ?? loginsError ?? failedLoginsError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!usersData || !loginsData || !failedLoginsData) {

--- a/src/widgets/autobrr/component.jsx
+++ b/src/widgets/autobrr/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (statsError || filtersError || indexersError) {
     const finalError = statsError ?? filtersError ?? indexersError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!statsData || !filtersData || !indexersData) {

--- a/src/widgets/bazarr/component.jsx
+++ b/src/widgets/bazarr/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
 
   if (moviesError || episodesError) {
     const finalError = moviesError ?? episodesError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!episodesData || !moviesData) {

--- a/src/widgets/changedetectionio/component.jsx
+++ b/src/widgets/changedetectionio/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data, error } = useWidgetAPI(widget, "info");
 
   if (error) {
-    return <Container error={error} />;
+    return <Container service={service} error={error} />;
   }
 
   if (!data) {

--- a/src/widgets/channelsdvrserver/component.jsx
+++ b/src/widgets/channelsdvrserver/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
   const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "status");
 
   if (channelsError) {
-    return <Container error={channelsError} />;
+    return <Container service={service} error={channelsError} />;
   }
 
   if (!channelsData) {

--- a/src/widgets/cloudflared/component.jsx
+++ b/src/widgets/cloudflared/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "cfd_tunnel");
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData) {

--- a/src/widgets/coinmarketcap/component.jsx
+++ b/src/widgets/coinmarketcap/component.jsx
@@ -38,7 +38,7 @@ export default function Component({ service }) {
   }
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData || !dateRange) {

--- a/src/widgets/deluge/component.jsx
+++ b/src/widgets/deluge/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: torrentData, error: torrentError } = useWidgetAPI(widget);
 
   if (torrentError) {
-    return <Container error={torrentError} />;
+    return <Container service={service} error={torrentError} />;
   }
 
   if (!torrentData) {

--- a/src/widgets/diskstation/component.jsx
+++ b/src/widgets/diskstation/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: utilizationData, error: utilizationError } = useWidgetAPI(widget, "utilization");
 
   if (storageError || infoError || utilizationError) {
-    return <Container error={ storageError ?? infoError ?? utilizationError } />;
+    return <Container service={service} error={ storageError ?? infoError ?? utilizationError } />;
   }
 
   if (!storageData || !infoData || !utilizationData) {

--- a/src/widgets/docker/component.jsx
+++ b/src/widgets/docker/component.jsx
@@ -19,7 +19,7 @@ export default function Component({ service }) {
 
   if (statsError || statsData?.error || statusError || statusData?.error) {
     const finalError = statsError ?? statsData?.error ?? statusError ?? statusData?.error;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (statusData && !(statusData.status.includes("running") || statusData.status.includes("partial"))) {

--- a/src/widgets/downloadstation/component.jsx
+++ b/src/widgets/downloadstation/component.jsx
@@ -10,7 +10,7 @@ export default function Component({ service }) {
   const { data: listData, error: listError } = useWidgetAPI(widget, "list");
 
   if (listError) {
-    return <Container error={listError} />;
+    return <Container service={service} error={listError} />;
   }
 
   const tasks = listData?.data?.tasks;

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -206,7 +206,7 @@ export default function Component({ service }) {
   }
 
   if (sessionsError || countError) {
-    return <Container error={sessionsError ?? countError} />;
+    return <Container service={service} error={sessionsError ?? countError} />;
   }
 
   const enableBlocks = service.widget?.enableBlocks

--- a/src/widgets/fileflows/component.jsx
+++ b/src/widgets/fileflows/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: fileflowsData, error: fileflowsError } = useWidgetAPI(widget, "status");
 
   if (fileflowsError) {
-    return <Container error={fileflowsError} />;
+    return <Container service={service} error={fileflowsError} />;
   }
 
   if (!fileflowsData) {

--- a/src/widgets/flood/component.jsx
+++ b/src/widgets/flood/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: torrentData, error: torrentError } = useWidgetAPI(widget, "torrents");
 
   if (torrentError || !torrentData?.torrents) {
-    return <Container error={torrentError ?? {message: "No torrent data returned"}} />;
+    return <Container service={service} error={torrentError ?? {message: "No torrent data returned"}} />;
   }
 
   if (!torrentData || !torrentData.torrents) {

--- a/src/widgets/freshrss/component.jsx
+++ b/src/widgets/freshrss/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: freshrssData, error: freshrssError } = useWidgetAPI(widget, "info");
 
   if (freshrssError) {
-    return <Container error={freshrssError} />;
+    return <Container service={service} error={freshrssError} />;
   }
 
   if (!freshrssData) {

--- a/src/widgets/ghostfolio/component.jsx
+++ b/src/widgets/ghostfolio/component.jsx
@@ -18,7 +18,7 @@ export default function Component({ service }) {
 
   if (ghostfolioErrorToday || ghostfolioErrorYear || ghostfolioErrorMax) {
     const finalError = ghostfolioErrorToday ?? ghostfolioErrorYear ?? ghostfolioErrorMax
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!performanceToday || !performanceYear || !performanceMax) {

--- a/src/widgets/gluetun/component.jsx
+++ b/src/widgets/gluetun/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: gluetunData, error: gluetunError } = useWidgetAPI(widget, "ip");
 
   if (gluetunError) {
-    return <Container error={gluetunError} />;
+    return <Container service={service} error={gluetunError} />;
   }
 
   if (!gluetunData) {

--- a/src/widgets/gotify/component.jsx
+++ b/src/widgets/gotify/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
 
   if (appsError || messagesError || clientsError) {
     const finalError = appsError ?? messagesError ?? clientsError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
 

--- a/src/widgets/grafana/component.jsx
+++ b/src/widgets/grafana/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: alertsData, error: alertsError } = useWidgetAPI(widget, "alerts");
 
   if (statsError || alertsError) {
-    return <Container error={statsError ?? alertsError} />;
+    return <Container service={service} error={statsError ?? alertsError} />;
   }
 
   if (!statsData || !alertsData) {

--- a/src/widgets/hdhomerun/component.jsx
+++ b/src/widgets/hdhomerun/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup");
 
   if (channelsError) {
-    return <Container error={channelsError} />;
+    return <Container service={service} error={channelsError} />;
   }
 
   if (!channelsData) {

--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -30,7 +30,7 @@ export default function Component({ service }) {
   const { data, error } = useWidgetAPI(widget, "checks");
 
   if (error) {
-    return <Container error={error} />;
+    return <Container service={service} error={error} />;
   }
 
   if (!data) {

--- a/src/widgets/homeassistant/component.jsx
+++ b/src/widgets/homeassistant/component.jsx
@@ -7,7 +7,7 @@ export default function Component({ service }) {
 
   const { data, error } = useWidgetAPI(widget, null, { refreshInterval: 60000 });
   if (error) {
-    return <Container error={error} />;
+    return <Container service={service} error={error} />;
   }
   
   return <Container service={service}>

--- a/src/widgets/homebridge/component.jsx
+++ b/src/widgets/homebridge/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: homebridgeData, error: homebridgeError } = useWidgetAPI(widget, "info");
 
   if (homebridgeError) {
-    return <Container error={homebridgeError} />;
+    return <Container service={service} error={homebridgeError} />;
   }
 
   if (!homebridgeData) {

--- a/src/widgets/immich/component.jsx
+++ b/src/widgets/immich/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
   const { data: immichData, error: immichError } = useWidgetAPI(widget);
 
   if (immichError || immichData?.statusCode === 401) {
-    return <Container error={immichError ?? immichData} />;
+    return <Container service={service} error={immichError ?? immichData} />;
   }
 
   if (!immichData) {

--- a/src/widgets/jackett/component.jsx
+++ b/src/widgets/jackett/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: indexersData, error: indexersError } = useWidgetAPI(widget, "indexers");
 
   if (indexersError) {
-    return <Container error={indexersError} />;
+    return <Container service={service} error={indexersError} />;
   }
 
   if (!indexersData) {

--- a/src/widgets/jellyseerr/component.jsx
+++ b/src/widgets/jellyseerr/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "request/count");
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData) {

--- a/src/widgets/komga/component.jsx
+++ b/src/widgets/komga/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
 
   if (libraryError || seriesError || bookError) {
     const finalError = libraryError ?? seriesError ?? bookError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!libraryData || !seriesData || !bookData) {

--- a/src/widgets/kopia/component.jsx
+++ b/src/widgets/kopia/component.jsx
@@ -38,7 +38,7 @@ export default function Component({ service }) {
   const { data: statusData, error: statusError } = useWidgetAPI(widget, "status");
 
   if (statusError) {
-    return <Container error={statusError} />;
+    return <Container service={service} error={statusError} />;
   }
 
   const source = statusData?.sources[0];

--- a/src/widgets/kubernetes/component.jsx
+++ b/src/widgets/kubernetes/component.jsx
@@ -16,7 +16,7 @@ export default function Component({ service }) {
     `/api/kubernetes/stats/${widget.namespace}/${widget.app}?${podSelectorString}`);
 
   if (statsError || statusError) {
-    return <Container error={t("widget.api_error")} />;
+    return <Container service={service} error={t("widget.api_error")} />;
   }
 
   if (statusData && statusData.status !== "running") {

--- a/src/widgets/lidarr/component.jsx
+++ b/src/widgets/lidarr/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (albumsError || wantedError || queueError) {
     const finalError = albumsError ?? wantedError ?? queueError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!albumsData || !wantedData || !queueData) {

--- a/src/widgets/mastodon/component.jsx
+++ b/src/widgets/mastodon/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "instance");
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData) {

--- a/src/widgets/medusa/component.jsx
+++ b/src/widgets/medusa/component.jsx
@@ -13,7 +13,7 @@ export default function Component({ service }) {
 
   if (statsError || futureError) {
     const finalError = statsError ?? futureError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!statsData || !futureData) {

--- a/src/widgets/mikrotik/component.jsx
+++ b/src/widgets/mikrotik/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
 
   if (statsError || leasesError) {
     const finalError = statsError ?? leasesError;
-    return <Container error={ finalError } />;
+    return <Container service={service} error={ finalError } />;
   }
 
   if (!statsData || !leasesData) {

--- a/src/widgets/minecraft/component.jsx
+++ b/src/widgets/minecraft/component.jsx
@@ -10,7 +10,7 @@ export default function Component({ service }) {
   const { t } = useTranslation();
   
   if(serverError){
-    return <Container error={serverError} />;
+    return <Container service={service} error={serverError} />;
   }
   if (!serverData) {
     return (

--- a/src/widgets/miniflux/component.jsx
+++ b/src/widgets/miniflux/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: minifluxData, error: minifluxError } = useWidgetAPI(widget, "counters");
 
   if (minifluxError) {
-    return <Container error={minifluxError} />;
+    return <Container service={service} error={minifluxError} />;
   }
 
   if (!minifluxData) {

--- a/src/widgets/moonraker/component.jsx
+++ b/src/widgets/moonraker/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (printStatsError || displayStatsError || webHooksError) {
     const finalError = printStatsError ?? displayStatsError ?? webHooksError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!printStats || !displayStatus || !webHooks) {

--- a/src/widgets/mylar/component.jsx
+++ b/src/widgets/mylar/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (seriesError || issuesError || wantedError) {
     const finalError = seriesError ?? issuesError ?? wantedError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!seriesData || !issuesData || !wantedData) {

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -27,7 +27,7 @@ export default function Component({ service }) {
   const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, "getNowPlaying");
 
   if (navidromeError || navidromeData?.["subsonic-response"]?.error) {
-    return <Container error={navidromeError ?? navidromeData?.["subsonic-response"]?.error} />;
+    return <Container service={service} error={navidromeError ?? navidromeData?.["subsonic-response"]?.error} />;
   }
 
   if (!navidromeData) {

--- a/src/widgets/nextcloud/component.jsx
+++ b/src/widgets/nextcloud/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
   const { data: nextcloudData, error: nextcloudError } = useWidgetAPI(widget, "serverinfo");
 
   if (nextcloudError) {
-    return <Container error={nextcloudError} />;
+    return <Container service={service} error={nextcloudError} />;
   }
 
   if (!nextcloudData) {

--- a/src/widgets/nextdns/component.jsx
+++ b/src/widgets/nextdns/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: nextdnsData, error: nextdnsError } = useWidgetAPI(widget, "analytics/status");
 
   if (nextdnsError) {
-    return <Container error={nextdnsError} />;
+    return <Container service={service} error={nextdnsError} />;
   }
 
   if (!nextdnsData) {

--- a/src/widgets/npm/component.jsx
+++ b/src/widgets/npm/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: infoData, error: infoError } = useWidgetAPI(widget, "nginx/proxy-hosts");
 
   if (infoError) {
-    return <Container error={infoError} />;
+    return <Container service={service} error={infoError} />;
   }
 
   if (!infoData) {

--- a/src/widgets/nzbget/component.jsx
+++ b/src/widgets/nzbget/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: statusData, error: statusError } = useWidgetAPI(widget, "status");
 
   if (statusError) {
-    return <Container error={statusError} />;
+    return <Container service={service} error={statusError} />;
   }
 
   if (!statusData) {

--- a/src/widgets/octoprint/component.jsx
+++ b/src/widgets/octoprint/component.jsx
@@ -9,11 +9,11 @@ export default function Component({ service }) {
   const { data: jobStats, error: jobStatsError } = useWidgetAPI(widget, "job_stats");
 
   if (printerStatsError) {
-    return <Container error={printerStatsError} />;
+    return <Container service={service} error={printerStatsError} />;
   }
 
   if (jobStatsError) {
-    return <Container error={jobStatsError} />;
+    return <Container service={service} error={jobStatsError} />;
   }
 
   const state = printerStats?.state?.text;

--- a/src/widgets/omada/component.jsx
+++ b/src/widgets/omada/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
   });
 
   if (omadaAPIError) {
-    return <Container error={omadaAPIError} />;
+    return <Container service={service} error={omadaAPIError} />;
   }
 
   if (!omadaData) {

--- a/src/widgets/ombi/component.jsx
+++ b/src/widgets/ombi/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "Request/count");
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData) {

--- a/src/widgets/opnsense/component.jsx
+++ b/src/widgets/opnsense/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
 
   if (activityError || interfaceError) {
     const finalError = activityError ?? interfaceError;
-    return <Container error={ finalError } />;
+    return <Container service={service} error={ finalError } />;
   }
 
   if (!activityData || !interfaceData) {

--- a/src/widgets/overseerr/component.jsx
+++ b/src/widgets/overseerr/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "request/count");
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData) {

--- a/src/widgets/paperlessngx/component.jsx
+++ b/src/widgets/paperlessngx/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: statisticsData, error: statisticsError } = useWidgetAPI(widget, "statistics");
 
   if (statisticsError) {
-    return <Container error={statisticsError} />;
+    return <Container service={service} error={statisticsError} />;
   }
 
   if (!statisticsData) {

--- a/src/widgets/photoprism/component.jsx
+++ b/src/widgets/photoprism/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: photoprismData, error: photoprismError } = useWidgetAPI(widget);
 
   if (photoprismError) {
-    return <Container error={photoprismError} />;
+    return <Container service={service} error={photoprismError} />;
   }
 
   if (!photoprismData) {

--- a/src/widgets/pihole/component.jsx
+++ b/src/widgets/pihole/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: piholeData, error: piholeError } = useWidgetAPI(widget, "summaryRaw");
 
   if (piholeError) {
-    return <Container error={piholeError} />;
+    return <Container service={service} error={piholeError} />;
   }
 
   if (!piholeData) {

--- a/src/widgets/plex/component.jsx
+++ b/src/widgets/plex/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
   });
 
   if (plexAPIError) {
-    return <Container error={plexAPIError} />;
+    return <Container service={service} error={plexAPIError} />;
   }
 
   if (!plexData) {

--- a/src/widgets/portainer/component.jsx
+++ b/src/widgets/portainer/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
   });
 
   if (containersError) {
-    return <Container error={containersError} />;
+    return <Container service={service} error={containersError} />;
   }
 
   if (!containersData) {
@@ -28,7 +28,7 @@ export default function Component({ service }) {
   }
 
   if (containersData.error) {
-    return <Container error={t("widget.api_error")} />;
+    return <Container service={service} error={t("widget.api_error")} />;
   }
 
   const running = containersData.filter((c) => c.State === "running").length;

--- a/src/widgets/prometheus/component.jsx
+++ b/src/widgets/prometheus/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
   const { data: targetsData, error: targetsError } = useWidgetAPI(widget, "targets");
 
   if (targetsError) {
-    return <Container error={targetsError} />;
+    return <Container service={service} error={targetsError} />;
   }
 
   if (!targetsData) {

--- a/src/widgets/prowlarr/component.jsx
+++ b/src/widgets/prowlarr/component.jsx
@@ -11,7 +11,7 @@ export default function Component({ service }) {
   const { data: grabsData, error: grabsError } = useWidgetAPI(widget, "indexerstats");
 
   if (grabsError) {
-    return <Container error={grabsError} />;
+    return <Container service={service} error={grabsError} />;
   }
 
   if (!grabsData) {

--- a/src/widgets/proxmox/component.jsx
+++ b/src/widgets/proxmox/component.jsx
@@ -16,7 +16,7 @@ export default function Component({ service }) {
   const { data: clusterData, error: clusterError } = useWidgetAPI(widget, "cluster/resources");
 
   if (clusterError) {
-    return <Container error={clusterError} />;
+    return <Container service={service} error={clusterError} />;
   }
 
   if (!clusterData || !clusterData.data) {

--- a/src/widgets/proxmoxbackupserver/component.jsx
+++ b/src/widgets/proxmoxbackupserver/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (datastoreError || tasksError || hostError) {
     const finalError = tasksError ?? datastoreError ?? hostError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!datastoreData || !tasksData || !hostData) {

--- a/src/widgets/pterodactyl/component.jsx
+++ b/src/widgets/pterodactyl/component.jsx
@@ -10,7 +10,7 @@ export default function Component({ service }) {
   const {data: nodesData, error: nodesError} = useWidgetAPI(widget, "nodes");
 
   if (nodesError) {
-    return <Container error={ nodesError } />;
+    return <Container service={service} error={ nodesError } />;
   }
 
   if (!nodesData) {

--- a/src/widgets/pyload/component.jsx
+++ b/src/widgets/pyload/component.jsx
@@ -10,7 +10,7 @@ export default function Component({ service }) {
   const { data: pyloadData, error: pyloadError } = useWidgetAPI(widget, "status");
 
   if (pyloadError) {
-    return <Container error={pyloadError} />;
+    return <Container service={service} error={pyloadError} />;
   }
 
   if (!pyloadData) {

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: torrentData, error: torrentError } = useWidgetAPI(widget, "torrents/info");
 
   if (torrentError) {
-    return <Container error={torrentError} />;
+    return <Container service={service} error={torrentError} />;
   }
 
   if (!torrentData) {

--- a/src/widgets/radarr/component.jsx
+++ b/src/widgets/radarr/component.jsx
@@ -13,7 +13,7 @@ export default function Component({ service }) {
 
   if (moviesError || queuedError) {
     const finalError = moviesError ?? queuedError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!moviesData || !queuedData) {

--- a/src/widgets/readarr/component.jsx
+++ b/src/widgets/readarr/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
 
   if (booksError || wantedError || queueError) {
     const finalError = booksError ?? wantedError ?? queueError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!booksData || !wantedData || !queueData) {

--- a/src/widgets/rutorrent/component.jsx
+++ b/src/widgets/rutorrent/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: statusData, error: statusError } = useWidgetAPI(widget);
 
   if (statusError) {
-    return <Container error={statusError} />;
+    return <Container service={service} error={statusError} />;
   }
 
   if (!statusData) {

--- a/src/widgets/sabnzbd/component.jsx
+++ b/src/widgets/sabnzbd/component.jsx
@@ -22,7 +22,7 @@ export default function Component({ service }) {
   const { data: queueData, error: queueError } = useWidgetAPI(widget, "queue");
 
   if (queueError) {
-    return <Container error={queueError} />;
+    return <Container service={service} error={queueError} />;
   }
 
   if (!queueData) {

--- a/src/widgets/scrutiny/component.jsx
+++ b/src/widgets/scrutiny/component.jsx
@@ -29,7 +29,7 @@ export default function Component({ service }) {
 
   if (scrutinyError || scrutinySettingsError) {
     const finalError = scrutinyError ?? scrutinySettingsError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!scrutinyData || !scrutinySettings) {

--- a/src/widgets/sonarr/component.jsx
+++ b/src/widgets/sonarr/component.jsx
@@ -14,7 +14,7 @@ export default function Component({ service }) {
 
   if (wantedError || queuedError || seriesError) {
     const finalError = wantedError ?? queuedError ?? seriesError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!wantedData || !queuedData || !seriesData) {

--- a/src/widgets/speedtest/component.jsx
+++ b/src/widgets/speedtest/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: speedtestData, error: speedtestError } = useWidgetAPI(widget, "speedtest/latest");
 
   if (speedtestError) {
-    return <Container error={speedtestError} />;
+    return <Container service={service} error={speedtestError} />;
   }
 
   if (!speedtestData) {

--- a/src/widgets/strelaysrv/component.jsx
+++ b/src/widgets/strelaysrv/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "status");
 
   if (statsError) {
-    return <Container error={statsError} />;
+    return <Container service={service} error={statsError} />;
   }
 
   if (!statsData) {

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -123,7 +123,7 @@ export default function Component({ service }) {
   });
 
   if (activityError) {
-    return <Container error={activityError} />;
+    return <Container service={service} error={activityError} />;
   }
 
   if (!activityData) {

--- a/src/widgets/tdarr/component.jsx
+++ b/src/widgets/tdarr/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: tdarrData, error: tdarrError } = useWidgetAPI(widget);
 
   if (tdarrError) {
-    return <Container error={tdarrError} />;
+    return <Container service={service} error={tdarrError} />;
   }
 
   if (!tdarrData) {

--- a/src/widgets/traefik/component.jsx
+++ b/src/widgets/traefik/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: traefikData, error: traefikError } = useWidgetAPI(widget, "overview");
 
   if (traefikError) {
-    return <Container error={traefikError} />;
+    return <Container service={service} error={traefikError} />;
   }
 
   if (!traefikData) {

--- a/src/widgets/transmission/component.jsx
+++ b/src/widgets/transmission/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: torrentData, error: torrentError } = useWidgetAPI(widget);
 
   if (torrentError) {
-    return <Container error={torrentError} />;
+    return <Container service={service} error={torrentError} />;
   }
 
   if (!torrentData) {

--- a/src/widgets/truenas/component.jsx
+++ b/src/widgets/truenas/component.jsx
@@ -43,7 +43,7 @@ export default function Component({ service }) {
 
   if (alertError || statusError) {
     const finalError = alertError ?? statusError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!alertData || !statusData) {

--- a/src/widgets/tubearchivist/component.jsx
+++ b/src/widgets/tubearchivist/component.jsx
@@ -16,7 +16,7 @@ export default function Component({ service }) {
 
   if (downloadsError || videosError || channelsError || playlistsError) {
     const finalError = downloadsError ?? videosError ?? channelsError ?? playlistsError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!downloadsData || !videosData || !channelsData || !playlistsData) {

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
     const { data: statsData, error: statsError } = useWidgetAPI(widget, "stat/sites");
 
     if (statsError) {
-        return <Container error={statsError} />;
+        return <Container service={service} error={statsError} />;
     }
 
     const defaultSite = widget.site ? statsData?.data.find(s => s.desc === widget.site) : statsData?.data?.find(s => s.name === "default");

--- a/src/widgets/unmanic/component.jsx
+++ b/src/widgets/unmanic/component.jsx
@@ -10,7 +10,7 @@ export default function Component({ service }) {
 
   if (workersError || pendingError) {
     const finalError = workersError ?? pendingError;
-    return <Container error={finalError} />;
+    return <Container service={service} error={finalError} />;
   }
 
   if (!workersData || !pendingData) {

--- a/src/widgets/uptimekuma/component.jsx
+++ b/src/widgets/uptimekuma/component.jsx
@@ -13,7 +13,7 @@ export default function Component({ service }) {
   const { data: heartbeatData, error: heartbeatError } = useWidgetAPI(widget, "heartbeat");
 
   if (statusError || heartbeatError) {
-    return <Container error={statusError ?? heartbeatError} />;
+    return <Container service={service} error={statusError ?? heartbeatError} />;
   }
 
   if (!statusData || !heartbeatData) {

--- a/src/widgets/watchtower/component.jsx
+++ b/src/widgets/watchtower/component.jsx
@@ -13,7 +13,7 @@ export default function Component({ service }) {
   const { data: watchData, error: watchError } = useWidgetAPI(widget, "watchtower");
 
   if (watchError) {
-    return <Container error={watchError} />;
+    return <Container service={service} error={watchError} />;
   }
 
   if (!watchData) {

--- a/src/widgets/whatsupdocker/component.jsx
+++ b/src/widgets/whatsupdocker/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { data: containersData, error: containersError } = useWidgetAPI(widget, "containers");
   
   if (containersError) {
-    return <Container error={containersError} />;
+    return <Container service={service} error={containersError} />;
   }
 
   if (!containersData) {

--- a/src/widgets/xteve/component.jsx
+++ b/src/widgets/xteve/component.jsx
@@ -12,7 +12,7 @@ export default function Component({ service }) {
   const { data: xteveData, error: xteveError } = useWidgetAPI(widget, "api");
 
   if (xteveError) {
-    return <Container error={xteveError} />;
+    return <Container service={service} error={xteveError} />;
   }
 
   if (!xteveData) {


### PR DESCRIPTION
## Proposed change

Adds a global (and per-service) setting to **prevent rendering the widget**, instead of showing a bright red API error box + message.

Closes #1355 

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/86
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
