### PR TITLE
Add Support for Simple Icons + Add optional theme colors for icons

### DIFF
--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -4,6 +4,10 @@ import Image from "next/future/image";
 import { SettingsContext } from "utils/contexts/settings";
 import { ThemeContext } from "utils/contexts/theme";
 
+const iconSetURLs = {
+  'mdi': "https://cdn.jsdelivr.net/npm/@mdi/svg@latest/svg/",
+  'si' : "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/",
+};
 
 export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "logo" }) {
   const { settings } = useContext(SettingsContext);
@@ -28,22 +32,12 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
 
   // check mdi- or si- prefixed icons
   const prefix = icon.split("-")[0]
-  const prefixPaths = {
-    'mdi': "https://cdn.jsdelivr.net/npm/@mdi/svg@latest/svg/",
-    'si' : "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/",
-  };
 
-  if (prefix in prefixPaths) {
+  if (prefix in iconSetURLs) {
     // get icon source
     const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
-    const iconSource = `${prefixPaths[prefix]}${iconName}.svg`;
+    const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
 
-    const gradientStyle = "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
-    const themeStyle = `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity))`;
-
-    const setting = settings.iconStyle || "gradient";
-    const background = setting === "gradient" ? gradientStyle : themeStyle;
-    
     return (
       <div
         style={{
@@ -51,7 +45,9 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
           height,
           maxWidth: '100%',
           maxHeight: '100%',
-          background,
+          background: settings.iconStyle === "theme" ?
+            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity))` :
+            "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
           mask: `url(${iconSource}) no-repeat center / contain`,
           WebkitMask: `url(${iconSource}) no-repeat center / contain`,
         }}

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -33,7 +33,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   };
 
   if (prefix in prefixPaths) {
-    // get icon Source
+    // get icon source
     const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
     const iconSource = `${prefixPaths[prefix]}${iconName}.svg`;
 

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -18,9 +18,16 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
     );
   }
 
-  // mdi- prefixed, material design icons
-  if (icon.startsWith("mdi-")) {
-    const iconName = icon.replace("mdi-", "").replace(".svg", "");
+  const prefix = icon.split("-")[0]
+  const prefixPaths = {
+    'mdi': "https://cdn.jsdelivr.net/npm/@mdi/svg@latest/svg/",
+    'si' : "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/",
+  };
+
+  if (prefix in prefixPaths) {
+    const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
+    const iconSource = `${prefixPaths[prefix]}${iconName}.svg`;
+
     return (
       <div
         style={{
@@ -29,8 +36,8 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
           maxWidth: '100%',
           maxHeight: '100%',
           background: "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
-          mask: `url(https://cdn.jsdelivr.net/npm/@mdi/svg@latest/svg/${iconName}.svg) no-repeat center / contain`,
-          WebkitMask: `url(https://cdn.jsdelivr.net/npm/@mdi/svg@latest/svg/${iconName}.svg) no-repeat center / contain`,
+          mask: `url(${iconSource}) no-repeat center / contain`,
+          WebkitMask: `url(${iconSource}) no-repeat center / contain`,
         }}
       />
     );

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -1,6 +1,14 @@
+import { useContext } from "react";
 import Image from "next/future/image";
 
+import { SettingsContext } from "utils/contexts/settings";
+import { ThemeContext } from "utils/contexts/theme";
+
+
 export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "logo" }) {
+  const { settings } = useContext(SettingsContext);
+  const { theme } = useContext(ThemeContext);
+
   // direct or relative URLs
   if (icon.startsWith("http") || icon.startsWith("/")) {
     return (
@@ -25,9 +33,16 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   };
 
   if (prefix in prefixPaths) {
+    // get icon Source
     const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
     const iconSource = `${prefixPaths[prefix]}${iconName}.svg`;
 
+    const gradientStyle = "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
+    const themeStyle = `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity))`;
+
+    const setting = settings.iconStyle || "gradient";
+    const background = setting === "gradient" ? gradientStyle : themeStyle;
+    
     return (
       <div
         style={{
@@ -35,7 +50,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
           height,
           maxWidth: '100%',
           maxHeight: '100%',
-          background: "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
+          background,
           mask: `url(${iconSource}) no-repeat center / contain`,
           WebkitMask: `url(${iconSource}) no-repeat center / contain`,
         }}

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -26,6 +26,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
     );
   }
 
+  // check mdi- or si- prefixed icons
   const prefix = icon.split("-")[0]
   const prefixPaths = {
     'mdi': "https://cdn.jsdelivr.net/npm/@mdi/svg@latest/svg/",


### PR DESCRIPTION
## Proposed change

I was setting up my homepage bookmarks to use material icons and there were two things that I wanted to address. The mask gradient wasn't the aesthetic I was going for and I saw a deprecation warning for most if not all of the brand icons in the material design icon set that I wanted to use.

I didn't look to see when the deprecation will go into effect but I don't think it hurts to implement something like this ahead of time.

Deprecation warning can be seen here; https://pictogrammers.com/library/mdi/icon/reddit/
Github Issue from maintainer with list: https://github.com/Templarian/MaterialDesign/issues/4901

### Simple Icon Support
I wanted to add support for simple-icons as suggested in the message from the mdi maintainer. The way that I implemented it anticipates support for other prefixes and should be completely backwards compatible. Essentially you can opt in to use the `si-` prefix and when mdi removes their brand icons, the `si-` prefix will still work.

### iconStyle Proposal
The proposed setting is called `iconStyle`, which defaults to `gradient` but can optionally be set to `theme`. Gradient behaves exactly as before and the new theme option will use the same css rule as the text for whichever theme is used. I thought this would be the most compliant implementation.


I am open to feedback and changes, the code style is a bit different than mine but I tried to conform to existing conventions. Let me know if you would like me to change anything. If you only want one of these changes, I would be happy to resubmit per your request.

Also if you would like a PR for the documentation before this is merged let me know.


Here are some example screen shots, there are obviously a lot of permutation but I think is is representative of the changes.

![mdi-](https://user-images.githubusercontent.com/1075609/235384157-a3e12645-6582-4ad2-af80-a53748c22da1.PNG)
mdi- and settings.iconStyle = "gradient" 

![mdi-theme](https://user-images.githubusercontent.com/1075609/235384158-0d662fbc-d23b-4c9c-b7c9-832cf18a9188.PNG)
mdi- prefix and settings.iconStyle = "theme"

![mdi-theme-light](https://user-images.githubusercontent.com/1075609/235384159-28fd246b-c907-4be6-9397-8dd4b5f7e7c1.PNG)
theme="light" and settings.iconStyle = "theme"

![si-](https://user-images.githubusercontent.com/1075609/235384160-6025318b-a623-461c-8305-3e91daf37837.PNG)
Bookmark Simple Icon with settings.iconStyle not specified


![si-service-dark](https://user-images.githubusercontent.com/1075609/235384161-07aa434a-a9da-4697-ac4b-378a9dfc7390.PNG)
Service Simple Icons with settings.iconStyle="theme"

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)
  - Future bug fix + new feature

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
