### PR TITLE
fallback for --tw-text-opacity

### DIFF
--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -48,7 +48,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
           maxWidth: '100%',
           maxHeight: '100%',
           background: settings.iconStyle === "theme" ?
-            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity))` :
+            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
             "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
           mask: `url(${iconSource}) no-repeat center / contain`,
           WebkitMask: `url(${iconSource}) no-repeat center / contain`,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

I encountered an issue with `iconStyle: theme` where for the service section icons, `--tw-text-opacity` was not set. I believe this was because since they aren't clickable they weren't nested in the hover css class which makes that var available. I am unsure why I didn't encounter this in my testing before. This PR adds a fallback so it will use the opacity if defined otherwise it will be opaque.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
