### PR TITLE
Fix: save space when services or bookmarks are not in use

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -286,7 +286,7 @@ function Home({ initialSettings }) {
           )}
         </div>
 
-        {services && (
+        {services?.length > 0 && (
           <div className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
             {services.map((group) => (
               <ServicesGroup key={group.name} services={group} layout={initialSettings.layout?.[group.name]} fiveColumns={settings.fiveColumns} />
@@ -294,7 +294,7 @@ function Home({ initialSettings }) {
           </div>
         )}
 
-        {bookmarks && (
+        {bookmarks?.length > 0 && (
           <div className={`grow flex flex-wrap pt-0 p-4 sm:p-8 gap-2 grid-cols-1 lg:grid-cols-2 lg:grid-cols-${Math.min(6, bookmarks.length)}`}>
             {bookmarks.map((group) => (
               <BookmarksGroup key={group.name} group={group} />


### PR DESCRIPTION
## Proposed change

When no bookmarks or no services configured in your homepage, some space can be saved...

![imatge](https://user-images.githubusercontent.com/13131391/235651215-97a13167-746e-49fe-9910-a27ef397d298.png)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
