### PR TITLE
Replace fields in Nextcloud widget with file count and shared item count

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -549,7 +549,9 @@
         "cpuload": "Cpu Load",
         "memoryusage": "Memory Usage",
         "freespace": "Free Space",
-        "activeusers": "Active Users"
+        "activeusers": "Active Users",
+        "numfiles": "Files",
+        "numshares": "Shared Items"
     },
     "kopia": {
         "status": "Status",

--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -33,5 +33,5 @@ export default function Container({ error = false, children, service }) {
     }));
   }
 
-  return <div className="relative flex flex-row w-full">{visibleChildren}</div>;
+  return <div className="relative flex flex-row w-full">{visibleChildren.slice(0, 4)}</div>;
 }

--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -33,5 +33,5 @@ export default function Container({ error = false, children, service }) {
     }));
   }
 
-  return <div className="relative flex flex-row w-full">{visibleChildren.slice(0, 4)}</div>;
+  return <div className="relative flex flex-row w-full">{visibleChildren}</div>;
 }

--- a/src/widgets/nextcloud/component.jsx
+++ b/src/widgets/nextcloud/component.jsx
@@ -13,16 +13,20 @@ export default function Component({ service }) {
   if (nextcloudError) {
     return <Container service={service} error={nextcloudError} />;
   }
+  
+  // cpuload & memoryusage were deprecated, dont break existing installs & dont have > 4 blocks total
+  let deprecatedFieldsCount = widget.fields ? widget.fields.includes('cpuload') + widget.fields.includes('memoryusage') : 0;
+  if (widget.fields && widget.fields.length - deprecatedFieldsCount < 4) deprecatedFieldsCount -= 4 - (widget.fields.length - deprecatedFieldsCount);
 
   if (!nextcloudData) {
     return (
       <Container service={service}>
-        <Block label="nextcloud.cpuload" />
-        <Block label="nextcloud.memoryusage" />
+        {widget.fields?.includes('cpuload') && <Block label="nextcloud.cpuload" />}
+        {widget.fields?.includes('memoryusage') && <Block label="nextcloud.memoryusage" />}
         <Block label="nextcloud.freespace" />
         <Block label="nextcloud.activeusers" />
-        <Block label="nextcloud.numfiles" />
-        <Block label="nextcloud.numshares" />
+        {deprecatedFieldsCount < 2 && <Block label="nextcloud.numfiles" />}
+        {deprecatedFieldsCount < 1 && <Block label="nextcloud.numshares" />}
       </Container>
     );
   }
@@ -32,12 +36,12 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="nextcloud.cpuload" value={t("common.percent", { value: nextcloudInfo.system.cpuload[0] })} />
-      <Block label="nextcloud.memoryusage" value={t("common.percent", { value:memoryUsage })} />
+      {widget.fields?.includes('cpuload') && <Block label="nextcloud.cpuload" value={t("common.percent", { value: nextcloudInfo.system.cpuload[0] })} />}
+      {widget.fields?.includes('memoryusage') && <Block label="nextcloud.memoryusage" value={t("common.percent", { value:memoryUsage })} />}
       <Block label="nextcloud.freespace" value={t("common.bbytes", { value: nextcloudInfo.system.freespace, maximumFractionDigits: 1 })} />
       <Block label="nextcloud.activeusers" value={t("common.number", { value: nextcloudData.ocs.data.activeUsers.last24hours })} />
-      <Block label="nextcloud.numfiles" value={t("common.number", { value: nextcloudInfo.storage.num_files })} />
-      <Block label="nextcloud.numshares" value={t("common.number", { value: nextcloudInfo.shares.num_shares })} />
+      {deprecatedFieldsCount < 2 && <Block label="nextcloud.numfiles" value={t("common.number", { value: nextcloudInfo.storage.num_files })} />}
+      {deprecatedFieldsCount < 1 && <Block label="nextcloud.numshares" value={t("common.number", { value: nextcloudInfo.shares.num_shares })} />}
     </Container>
   );
 }

--- a/src/widgets/nextcloud/component.jsx
+++ b/src/widgets/nextcloud/component.jsx
@@ -21,6 +21,8 @@ export default function Component({ service }) {
         <Block label="nextcloud.memoryusage" />
         <Block label="nextcloud.freespace" />
         <Block label="nextcloud.activeusers" />
+        <Block label="nextcloud.numfiles" />
+        <Block label="nextcloud.numshares" />
       </Container>
     );
   }
@@ -33,7 +35,9 @@ export default function Component({ service }) {
       <Block label="nextcloud.cpuload" value={t("common.percent", { value: nextcloudInfo.system.cpuload[0] })} />
       <Block label="nextcloud.memoryusage" value={t("common.percent", { value:memoryUsage })} />
       <Block label="nextcloud.freespace" value={t("common.bbytes", { value: nextcloudInfo.system.freespace, maximumFractionDigits: 1 })} />
-      <Block label="nextcloud.activeusers" value={t("common.number", { value: nextcloudData.ocs.data.activeUsers.last5minutes })} />
+      <Block label="nextcloud.activeusers" value={t("common.number", { value: nextcloudData.ocs.data.activeUsers.last24hours })} />
+      <Block label="nextcloud.numfiles" value={t("common.number", { value: nextcloudInfo.storage.num_files })} />
+      <Block label="nextcloud.numshares" value={t("common.number", { value: nextcloudInfo.shares.num_shares })} />
     </Container>
   );
 }

--- a/src/widgets/nextcloud/component.jsx
+++ b/src/widgets/nextcloud/component.jsx
@@ -14,19 +14,21 @@ export default function Component({ service }) {
     return <Container service={service} error={nextcloudError} />;
   }
   
-  // cpuload & memoryusage were deprecated, dont break existing installs & dont have > 4 blocks total
-  let deprecatedFieldsCount = widget.fields ? widget.fields.includes('cpuload') + widget.fields.includes('memoryusage') : 0;
-  if (widget.fields && widget.fields.length - deprecatedFieldsCount < 4) deprecatedFieldsCount -= 4 - (widget.fields.length - deprecatedFieldsCount);
+  // cpuload & memoryusage are deprecated, so limit to 4 fields
+  const showCpuLoad = widget.fields?.includes('cpuload');
+  const showMemoryUsage = widget.fields?.includes('memoryusage');
+  const showNumFiles = !showCpuLoad || !showMemoryUsage; // at least 1 deprecated field is hidden
+  const showNumShares = !showCpuLoad && !showMemoryUsage; // both deprecated fields are hidden
 
   if (!nextcloudData) {
     return (
       <Container service={service}>
-        {widget.fields?.includes('cpuload') && <Block label="nextcloud.cpuload" />}
-        {widget.fields?.includes('memoryusage') && <Block label="nextcloud.memoryusage" />}
+        {showCpuLoad && <Block label="nextcloud.cpuload" />}
+        {showMemoryUsage && <Block label="nextcloud.memoryusage" />}
         <Block label="nextcloud.freespace" />
         <Block label="nextcloud.activeusers" />
-        {deprecatedFieldsCount < 2 && <Block label="nextcloud.numfiles" />}
-        {deprecatedFieldsCount < 1 && <Block label="nextcloud.numshares" />}
+        {showNumFiles && <Block label="nextcloud.numfiles" />}
+        {showNumShares && <Block label="nextcloud.numshares" />}
       </Container>
     );
   }
@@ -36,12 +38,12 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      {widget.fields?.includes('cpuload') && <Block label="nextcloud.cpuload" value={t("common.percent", { value: nextcloudInfo.system.cpuload[0] })} />}
-      {widget.fields?.includes('memoryusage') && <Block label="nextcloud.memoryusage" value={t("common.percent", { value:memoryUsage })} />}
+      {showCpuLoad && <Block label="nextcloud.cpuload" value={t("common.percent", { value: nextcloudInfo.system.cpuload[0] })} />}
+      {showMemoryUsage && <Block label="nextcloud.memoryusage" value={t("common.percent", { value:memoryUsage })} />}
       <Block label="nextcloud.freespace" value={t("common.bbytes", { value: nextcloudInfo.system.freespace, maximumFractionDigits: 1 })} />
       <Block label="nextcloud.activeusers" value={t("common.number", { value: nextcloudData.ocs.data.activeUsers.last24hours })} />
-      {deprecatedFieldsCount < 2 && <Block label="nextcloud.numfiles" value={t("common.number", { value: nextcloudInfo.storage.num_files })} />}
-      {deprecatedFieldsCount < 1 && <Block label="nextcloud.numshares" value={t("common.number", { value: nextcloudInfo.shares.num_shares })} />}
+      {showNumFiles && <Block label="nextcloud.numfiles" value={t("common.number", { value: nextcloudInfo.storage.num_files })} />}
+      {showNumShares && <Block label="nextcloud.numshares" value={t("common.number", { value: nextcloudInfo.shares.num_shares })} />}
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

I find that `CPU Load` and `Memory Usage` are pointless to query from Nextcloud, seeing as we have other ways to get that information from the system hosting it (resources, glances, etc.). So I've replaced them with `Files` and `Shared`.

Also adds a setting to the widget to choose the last active range (5 minutes, 1 hour, 24 hours).

<img width="585" alt="Screenshot 2023-05-03 at 1 02 16 PM" src="https://user-images.githubusercontent.com/3247106/235988116-104ec7e7-2c11-40ab-87d6-9620557d76b9.png">

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/88
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
