### PR TITLE
PiHole widget: added new Percentage block

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -214,8 +214,8 @@
     "pihole": {
         "queries": "Queries",
         "blocked": "Blocked",
-        "gravity": "Gravity",
-        "percentage": "Percentage"
+        "blocked_percent": "Blocked %",
+        "gravity": "Gravity"
     },
     "adguard": {
         "queries": "Queries",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -214,7 +214,8 @@
     "pihole": {
         "queries": "Queries",
         "blocked": "Blocked",
-        "gravity": "Gravity"
+        "gravity": "Gravity",
+        "percentage": "Percentage"
     },
     "adguard": {
         "queries": "Queries",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -107,7 +107,6 @@
     "pihole": {
         "queries": "Richieste",
         "blocked": "Bloccati",
-        "percentage": "Percentuale",
         "gravity": "Severità"
     },
     "npm": {

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -107,6 +107,7 @@
     "pihole": {
         "queries": "Richieste",
         "blocked": "Bloccati",
+        "percentage": "Percentuale",
         "gravity": "Severità"
     },
     "npm": {

--- a/src/widgets/pihole/component.jsx
+++ b/src/widgets/pihole/component.jsx
@@ -20,7 +20,7 @@ export default function Component({ service }) {
       <Container service={service}>
         <Block label="pihole.queries" />
         <Block label="pihole.blocked" />
-		<Block label="pihole.percentage" />
+        <Block label="pihole.blocked_percent" />
         <Block label="pihole.gravity" />
       </Container>
     );
@@ -30,7 +30,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="pihole.queries" value={t("common.number", { value: parseInt(piholeData.dns_queries_today, 10) })} />
       <Block label="pihole.blocked" value={t("common.number", { value: parseInt(piholeData.ads_blocked_today, 10) })} />
-      <Block label="pihole.percentage" value={t("common.number", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })} />
+      <Block label="pihole.blocked_percent" value={t("common.percent", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })} />
       <Block label="pihole.gravity" value={t("common.number", { value: parseInt(piholeData.domains_being_blocked, 10) })} />
     </Container>
   );

--- a/src/widgets/pihole/component.jsx
+++ b/src/widgets/pihole/component.jsx
@@ -20,6 +20,7 @@ export default function Component({ service }) {
       <Container service={service}>
         <Block label="pihole.queries" />
         <Block label="pihole.blocked" />
+		<Block label="pihole.percentage" />
         <Block label="pihole.gravity" />
       </Container>
     );
@@ -29,6 +30,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="pihole.queries" value={t("common.number", { value: parseInt(piholeData.dns_queries_today, 10) })} />
       <Block label="pihole.blocked" value={t("common.number", { value: parseInt(piholeData.ads_blocked_today, 10) })} />
+      <Block label="pihole.percentage" value={t("common.number", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })} />
       <Block label="pihole.gravity" value={t("common.number", { value: parseInt(piholeData.domains_being_blocked, 10) })} />
     </Container>
   );

--- a/src/widgets/pihole/widget.js
+++ b/src/widgets/pihole/widget.js
@@ -10,6 +10,7 @@ const widget = {
       validate: [
         "dns_queries_today",
         "ads_blocked_today",
+        "ads_percentage_today",
         "domains_being_blocked"
       ]
     },


### PR DESCRIPTION
## Proposed change

Added a new block in the PiHole widget that shows the percentage of blocked queries as shown in the PiHole's admin page.

![image](https://user-images.githubusercontent.com/35406071/236674095-65100257-04b0-4cb8-9a26-5679a26f20fa.png)


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here:  https://github.com/benphelps/homepage-docs/pull/92
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
