### PR TITLE
Add support for dashboard-icons SVG file format

### DIFF
--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -57,7 +57,27 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
     );
   }
 
+ 
   // fallback to dashboard-icons
+  if (icon.endsWith(".svg")) {
+    const iconName = icon.replace(".svg", "");
+    return (
+      <Image
+        src={`https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/svg/${iconName}.svg`}
+        width={width}
+        height={height}
+        style={{
+          width,
+          height,
+          objectFit: "contain",
+          maxHeight: "100%",
+          maxWidth: "100%"
+        }}
+        alt={alt}
+      />
+    );
+  }
+  
   const iconName = icon.replace(".png", "");
   return (
     <Image


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->
On my personal homepage I usually use dashboard-icons. Up until now I've only used PNGs but since they introduced some changes some of my icons are only available in SVG format for now. I think since dashboard-icons supports SVGs the user should have the choice what file format they want to use for their icons.

It's completely backwards compatible and the change only takes effect if the user specifies an icon with the .svg ending as compared to .png, so for switching file formats on dashboard-icons the user only has to change the file ending in the config yaml file. All other cases where the user uses SVGs are unaffected.


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

Added SVG support for dashboard-icons.

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.