### PR TITLE
New Widget: Gitea

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -596,10 +596,15 @@
     },
     "gitea": {
       "notifications": "Notifications",
-      "Issue": "Issues",
-      "Pull": "Pull Requests",
-      "Commit": "Commits",
-      "Repository": "Repositories"
+      "issue": "Issues",
+      "pull": "Pull Requests",
+      "commit": "Commits",
+      "repository": "Repositories",
+      "followers": "Followers",
+      "following": "Following",
+      "repos": "Repositories",
+      "forks": "Stars",
+      "stars": "Forks"
     },
     "audiobookshelf": {
         "podcasts": "Podcasts",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -594,6 +594,13 @@
         "gross_percent_1y": "One year",
         "gross_percent_max": "All time"
     },
+    "gitea": {
+      "notifications": "Notifications",
+      "Issue": "Issues",
+      "Pull": "Pull Requests",
+      "Commit": "Commits",
+      "Repository": "Repositories"
+    },
     "audiobookshelf": {
         "podcasts": "Podcasts",
         "books": "Books",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -19,6 +19,7 @@ const components = {
   fileflows: dynamic(() => import("./fileflows/component")),
   flood: dynamic(() => import("./flood/component")),
   freshrss: dynamic(() => import("./freshrss/component")),
+  gitea: dynamic(() => import("./gitea/component")),
   ghostfolio: dynamic(() => import("./ghostfolio/component")),
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -5,41 +5,73 @@ import Container from "components/services/widget/container";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 
+function hasField(fields, fieldTypes) {
+  return fields.some(field => fieldTypes.includes(field));
+}
 
-
-export default function Component ({ service }) {
+export default function Component({ service }) {
   const { t } = useTranslation();
+  let data = {};
 
   const { widget } = service;
+  const fields = widget.fields ?? ["repos", "followers", "notifications"];
 
-  const { data: notifications, error: giteaError } = useWidgetAPI(widget, "allNotifications");
-  const notificationTypes = (notifications ?? []).reduce((acc, notification) => {
-      acc[notification.subject.type].push(notification);
-      return acc;
-    }
-    , {
-      "Issue": [],
-      "Pull": [],
-      "Commit": [],
-      "Repository": []
-    }
-  );
+  // Different fields require different API calls
+  const notificationFields = ["notifications", "issue", "pull", "commit", "repository"];
+  const userFields = ["followers", "following"];
+  const repoFields = ["repos", "stars", "forks"];
 
-  if (giteaError) {
-    return <Container service={service} error={giteaError} />;
+  if (hasField(fields, userFields)) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { data: user, error: userError } = useWidgetAPI(widget, "user");
+    if (userError) {
+      return <Container service={service} error={userError} />;
+    }
+    data = { ...data, followers: user?.followers_count, following: user?.following_count };
+
   }
 
-  if (!notifications) return (
-    <Container service={service}>
-      <Block label="gitea.notifications" />
-    </Container>
-  );
+  if (hasField(fields, repoFields)) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { data: repos, error: repoError } = useWidgetAPI(widget, "repos");
+    if (repoError) {
+      return <Container service={service} error={repoError} />;
+    }
+    const repoStats = (repos ?? []).reduce((acc, repo) => {
+      acc.repos += 1;
+      acc.stars += repo.stars_count;
+      acc.forks += repo.forks_count;
+      return acc;
+    }, { repos: 0, stars: 0, forks: 0 });
+
+    data = { ...data, ...repoStats };
+  }
+
+  if (hasField(fields, notificationFields)) {
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { data: notifications, error: notificationError } = useWidgetAPI(widget, "notifications");
+
+    if (notificationError) {
+      return <Container service={service} error={notificationError} />;
+    }
+
+    const notificationTypes = (notifications ?? []).reduce((acc, notification) => {
+        acc[notification.subject.type.toLowerCase()] += 1;
+        acc.notifications += 1;
+        return acc;
+      }, {
+        "notifications": 0, "issue": 0, "pull": 0, "commit": 0, "repository": 0
+      }
+    );
+
+    data = { ...data, ...notificationTypes };
+  }
 
   return (
     <Container service={service}>
-      {Object.keys(notificationTypes).map((type) =>
-        <Block key={type} label={`gitea.${type}`}
-               value={t("common.number", { value: notificationTypes[type].length })} />
+      {fields.map((field) =>
+        <Block key={field} label={`gitea.${field}`} value={data[field] ? t("common.number", { value: data[field] }) : '-'} />
       )}
     </Container>
   );

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -1,0 +1,46 @@
+import { useTranslation } from "next-i18next";
+
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+
+
+
+export default function Component ({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: notifications, error: giteaError } = useWidgetAPI(widget, "allNotifications");
+  const notificationTypes = (notifications ?? []).reduce((acc, notification) => {
+      acc[notification.subject.type].push(notification);
+      return acc;
+    }
+    , {
+      "Issue": [],
+      "Pull": [],
+      "Commit": [],
+      "Repository": []
+    }
+  );
+
+  if (giteaError) {
+    return <Container service={service} error={giteaError} />;
+  }
+
+  if (!notifications) return (
+    <Container service={service}>
+      <Block label="gitea.notifications" />
+    </Container>
+  );
+
+  return (
+    <Container service={service}>
+      {Object.keys(notificationTypes).map((type) =>
+        <Block key={type} label={`gitea.${type}`}
+               value={t("common.number", { value: notificationTypes[type].length })} />
+      )}
+    </Container>
+  );
+}

--- a/src/widgets/gitea/widget.js
+++ b/src/widgets/gitea/widget.js
@@ -1,16 +1,19 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  api: "{url}/api/v1/{endpoint}?access_token={key}",
+  api: "{url}/api/{endpoint}?access_token={key}",
   proxyHandler: genericProxyHandler,
 
   mappings: {
-    "allNotifications": {
-      endpoint: "notifications",
+    "notifications": {
+      endpoint: "v1/notifications", // required scope: notification
     },
-    "newNotifications": {
-      endpoint: "notifications/new",
+    "user": {
+      endpoint: "v1/user",
     },
+    "repos": {
+      endpoint: "v1/user/repos", // required scope: repo
+    }
   },
 };
 

--- a/src/widgets/gitea/widget.js
+++ b/src/widgets/gitea/widget.js
@@ -1,0 +1,17 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}?access_token={key}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    "allNotifications": {
+      endpoint: "notifications",
+    },
+    "newNotifications": {
+      endpoint: "notifications/new",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -15,6 +15,7 @@ import fileflows from "./fileflows/widget";
 import flood from "./flood/widget";
 import freshrss from "./freshrss/widget";
 import ghostfolio from "./ghostfolio/widget";
+import gitea from "./gitea/widget";
 import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
 import grafana from "./grafana/widget";
@@ -97,6 +98,7 @@ const widgets = {
   flood,
   freshrss,
   ghostfolio,
+  gitea,
   gluetun,
   gotify,
   grafana,


### PR DESCRIPTION
## Proposed change

Adding a new widget for Gitea. Gitea is a self-hosted all-in-one software development service, it includes Git hosting, code review, team collaboration, package registry and CI/CD. It is similar to GitHub, Bitbucket and GitLab.

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

It provides the following fields from Gitea: `["repos", "followers", "notifications", "issue", "pull", "commit", "repository", "stars", "following", "forks"]`

![image](https://github.com/benphelps/homepage/assets/1159009/2c472979-efb8-46e2-a7e4-f2d0b579d485)

While Gitea is intended to be self-hosted, there are public instances available for testing & viewing api output.

Example API: [https://opendev.org/api/swagger](https://opendev.org/api/swagger)

## Usage
API key can be created from `Settings > Application > Generate Token`.  Give the token a name and add the `repo` and `notification` scopes.

By default the `["repos", "followers", "notifications"]` fields are enabled. The full list of fields is: `["repos", "followers", "notifications", "issue", "pull", "commit", "repository", "stars", "following", "forks"]`

```yaml
widget:
  type: gitea
  url: http://gitea.host.or.ip
  key: <api_key>
```


## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

## Comments
- I haven't updated the documentation yet, I will once I get confirmation that this is looking good.
- I had to disable `rules-of-hooks` eslint rule in order to reduce the number of API calls. Is there a better way to handle this? It shouldn't cause any issues in real-world usage. It can cause issues during development if the fields change. This is fixed with a full page reload.
