### PR TITLE
Added PiAlert widget [WIP]

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -217,6 +217,12 @@
         "approved": "Approved",
         "available": "Available"
     },
+    "pialert": {
+        "total": "Total",
+        "connected": "Connected",
+        "new_devices": "New Devices",
+        "down_alerts": "Down Alerts"
+    },
     "pihole": {
         "queries": "Queries",
         "blocked": "Blocked",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -54,6 +54,7 @@ const components = {
   paperlessngx: dynamic(() => import("./paperlessngx/component")),
   photoprism: dynamic(() => import("./photoprism/component")),
   proxmoxbackupserver: dynamic(() => import("./proxmoxbackupserver/component")),
+  pialert: dynamic(() => import("./pialert/component")),
   pihole: dynamic(() => import("./pihole/component")),
   plex: dynamic(() => import("./plex/component")),
   portainer: dynamic(() => import("./portainer/component")),

--- a/src/widgets/pialert/component.jsx
+++ b/src/widgets/pialert/component.jsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: piholeData, error: piholeError } = useWidgetAPI(widget, "data");
+
+  if (piholeError) {
+    return <Container service={service} error={piholeError} />;
+  }
+
+  if (!piholeData) {
+    return (
+      <Container service={service}>
+        <Block label="pialert.total" />
+        <Block label="pialert.connected" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="pialert.total" value={t("common.number", { value: parseInt(piholeData[0], 10) })} />
+      <Block label="pialert.connected" value={t("common.number", { value: parseInt(piholeData[1], 10) })} />
+      <Block label="pialert.new_devices" value={t("common.number", { value: parseInt(piholeData[3], 10) })} />
+      <Block label="pialert.down_alerts" value={t("common.number", { value: parseInt(piholeData[4], 10) })} />
+    </Container>
+  );
+}

--- a/src/widgets/pialert/component.jsx
+++ b/src/widgets/pialert/component.jsx
@@ -9,27 +9,29 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  const { data: piholeData, error: piholeError } = useWidgetAPI(widget, "data");
+  const { data: pialertData, error: pialertError } = useWidgetAPI(widget, "data");
 
-  if (piholeError) {
-    return <Container service={service} error={piholeError} />;
+  if (pialertError) {
+    return <Container service={service} error={pialertError} />;
   }
 
-  if (!piholeData) {
+  if (!pialertData) {
     return (
       <Container service={service}>
         <Block label="pialert.total" />
         <Block label="pialert.connected" />
+        <Block label="pialert.new_devices" />
+        <Block label="pialert.down_alerts" />
       </Container>
     );
   }
 
   return (
     <Container service={service}>
-      <Block label="pialert.total" value={t("common.number", { value: parseInt(piholeData[0], 10) })} />
-      <Block label="pialert.connected" value={t("common.number", { value: parseInt(piholeData[1], 10) })} />
-      <Block label="pialert.new_devices" value={t("common.number", { value: parseInt(piholeData[3], 10) })} />
-      <Block label="pialert.down_alerts" value={t("common.number", { value: parseInt(piholeData[4], 10) })} />
+      <Block label="pialert.total" value={t("common.number", { value: parseInt(pialertData[0], 10) })} />
+      <Block label="pialert.connected" value={t("common.number", { value: parseInt(pialertData[1], 10) })} />
+      <Block label="pialert.new_devices" value={t("common.number", { value: parseInt(pialertData[3], 10) })} />
+      <Block label="pialert.down_alerts" value={t("common.number", { value: parseInt(pialertData[4], 10) })} />
     </Container>
   );
 }

--- a/src/widgets/pialert/widget.js
+++ b/src/widgets/pialert/widget.js
@@ -1,7 +1,6 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  //api: "{url}/api/table_custom_endpoint.json",
   api: "{url}/php/server/devices.php?action=getDevicesTotals",
   proxyHandler: genericProxyHandler,
 

--- a/src/widgets/pialert/widget.js
+++ b/src/widgets/pialert/widget.js
@@ -1,0 +1,15 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  //api: "{url}/api/table_custom_endpoint.json",
+  api: "{url}/php/server/devices.php?action=getDevicesTotals",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    "data": {
+      endpoint: "data",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -48,6 +48,7 @@ import overseerr from "./overseerr/widget";
 import paperlessngx from "./paperlessngx/widget";
 import photoprism from "./photoprism/widget";
 import proxmoxbackupserver from "./proxmoxbackupserver/widget";
+import pialert from "./pialert/widget";
 import pihole from "./pihole/widget";
 import plex from "./plex/widget";
 import portainer from "./portainer/widget";
@@ -132,6 +133,7 @@ const widgets = {
   paperlessngx,
   photoprism,
   proxmoxbackupserver,
+  pialert,
   pihole,
   plex,
   portainer,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->

This PR introduces the new PiAlert widget that pulls stats from PiAlert's APi (https://github.com/jokob-sk/Pi.Alert).

![image](https://github.com/benphelps/homepage/assets/35406071/893a7c17-6034-4fcb-8b38-69958e302535)

The user will be able to add the widget to the services.yaml file using the following configuration:

```yaml
widget:
    type: pialert
    url: http://ip:port
```

The PiAlert's API are not documented, I am using as endpoint /php/server/devices.php?action=getDevicesTotals, that returns the following response:

```js
[30,22,0,0,0,0]
```

It is an array where each item corresponds respectively to AllDevices, Connected, Favorites, NewDevices, DownAlerts, Archived.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/101
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
