### PR TITLE
Add GitHub widget | Qty. of stars and open issues right on the Homepage

### DIFF
--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -55,6 +55,8 @@ export default async function credentialedProxyHandler(req, res, map) {
         } else {
           headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
         }
+      } else if (widget.type === "github") {
+        headers["User-Agent"] = `homepage`;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -20,6 +20,7 @@ const components = {
   flood: dynamic(() => import("./flood/component")),
   freshrss: dynamic(() => import("./freshrss/component")),
   ghostfolio: dynamic(() => import("./ghostfolio/component")),
+  github: dynamic(() => import("./github/component")),
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),
   grafana: dynamic(() => import("./grafana/component")),

--- a/src/widgets/github/component.jsx
+++ b/src/widgets/github/component.jsx
@@ -1,0 +1,30 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+
+  const { widget } = service;
+
+  const { data: githubData, error: githubError } = useWidgetAPI(widget);
+
+  if (githubError) {
+    return <Container service={service} error={githubError} />;
+  }
+
+  if (!githubData) {
+    return (
+      <Container service={service}>
+        <Block label="open issues" />
+        <Block label="stars" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="open issues" value={githubData.open_issues_count} />
+      <Block label="stars" value={githubData.stargazers_count} />
+    </Container>
+  );
+}

--- a/src/widgets/github/widget.js
+++ b/src/widgets/github/widget.js
@@ -1,0 +1,8 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "https://api.github.com/repos/{owner}/{repo}",
+  proxyHandler: credentialedProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -15,6 +15,7 @@ import fileflows from "./fileflows/widget";
 import flood from "./flood/widget";
 import freshrss from "./freshrss/widget";
 import ghostfolio from "./ghostfolio/widget";
+import github from "./github/widget";
 import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
 import grafana from "./grafana/widget";
@@ -99,6 +100,7 @@ const widgets = {
   flood,
   freshrss,
   ghostfolio,
+  github,
   gluetun,
   gotify,
   grafana,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget. See the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
-->
When maintaining GitHub repository it will be useful to have handy view on statistics about it.
I propose qty. of stars and open issues. Other to be discussed - what could be practical for you?

![image](https://github.com/benphelps/homepage/assets/114079646/fd9af745-4e20-47ad-b6d6-b9e2d7ebc899)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: [Homepage Docs Pull Request #98](https://github.com/benphelps/homepage-docs/pull/98)
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
