### PR TITLE
added daily quote widget as an information widget, swizzin and glances as service widgets

### DIFF
--- a/src/components/widgets/quote/quote.jsx
+++ b/src/components/widgets/quote/quote.jsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import useSWR from "swr";
+
+const textSizes = {
+  "4xl": "text-4xl",
+  "3xl": "text-3xl",
+  "2xl": "text-2xl",
+  xl: "text-xl",
+  lg: "text-lg",
+  md: "text-md",
+  sm: "text-sm",
+  xs: "text-xs",
+};
+
+export default function DailyQuote({ options }) {
+  const { text_size: textSize, width } = options;
+  const [quote, setQuote] = useState(null);
+
+  useSWR("https://api.quotable.io/random", {
+    onSuccess: (data) => {
+      setQuote(data);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+
+  if (!quote) {
+    return null;
+  }
+
+  const textClass = `quote-content ${textSizes[textSize || "lg"]} text-theme-800 dark:text-theme-200`;
+  const wrapperStyle = { width };
+
+  return (
+    <div className="flex flex-col justify-center ml-4" style={wrapperStyle}>
+      <div className={textClass}>
+        &ldquo;{quote.content}&rdquo;
+      </div>
+      <div className="quote-author">{quote.author}</div>
+    </div>
+  );
+}

--- a/src/widgets/glances/component.jsx
+++ b/src/widgets/glances/component.jsx
@@ -1,0 +1,50 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function convertToFahrenheit(t) {
+  return t * 9/5 + 32;
+}
+
+export default function GlancesStats({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: memData, error: memError } = useWidgetAPI(widget, "mem");
+  const { data: tempData, error: tempError } = useWidgetAPI(widget, "temp");
+
+  if (memError || tempError) {
+    return <Container error={memError || tempError} />;
+  }
+
+  if (!memData || !tempData) {
+    return (
+      <Container service={service}>
+        <Block label="Memory Usage" value="N/A" />
+        <Block label="Temperature" value="N/A" />
+      </Container>
+    );
+  }
+
+  const unit = "celsius";
+  const memPercent = Math.round((memData.used / memData.total) * 100);
+  const tempValue = tempData[0].value;
+
+  return (
+    <Container service={service}>
+      <Block label="Memory" value={`${memPercent}%`} />
+      <Block
+        label="Temp"
+        value={`${t("common.number", {
+          value: unit === "celsius" ? tempValue : convertToFahrenheit(tempValue),
+          style: "unit",
+          unit,
+          maximumFractionDigits: 1,
+        })}`}
+      />
+    </Container>
+  );
+}

--- a/src/widgets/glances/widget.js
+++ b/src/widgets/glances/widget.js
@@ -1,0 +1,24 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/3/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    mem: {
+      endpoint: "mem",
+    },
+    temp: {
+      endpoint: "sensors",
+    },
+  },
+};
+
+export default widget;
+
+
+
+
+
+
+

--- a/src/widgets/swizzin/component.jsx
+++ b/src/widgets/swizzin/component.jsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function SwizzinStats({ service }) {
+  // eslint-disable-next-line no-unused-vars
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: ramData, error: ramError } = useWidgetAPI(widget, "ram");
+  const { data: diskData, error: diskError } = useWidgetAPI(widget, "disk");
+
+  if (ramError || diskError) {
+    return <Container error={ramError || diskError} />;
+  }
+
+  if (!ramData || !diskData) {
+    return (
+      <Container service={service}>
+        <Block label="RAM Free" />
+        <Block label="Disk Free" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="RAM Free" value={ramData.ramfree} />
+      <Block label="Disk Free" value={diskData["/mnt/media"].diskfree} />
+    </Container>
+  );
+}
+

--- a/src/widgets/swizzin/widget.js
+++ b/src/widgets/swizzin/widget.js
@@ -1,0 +1,24 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/stats/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    ram: {
+      endpoint: "ram",
+    },
+    disk: {
+      endpoint: "disk",
+    },
+  },
+};
+
+export default widget;
+
+
+
+
+
+
+


### PR DESCRIPTION
## Proposed change

    gets daily quote from https://api.quotable.io/random
    Options for text_size and width:
        - quote: 
             text_size: md, 
             width: 400px
    Service widget for Swizzin users
    Service widget to have glances as a service instead of an information widget



## Type of change


New information widget and 2 new service widgets




## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
![image](https://github.com/benphelps/homepage/assets/16037573/64698588-e8e7-46ad-8a88-cc84c8292597) 
![image](https://github.com/benphelps/homepage/assets/16037573/6702e0bb-6c64-4906-80bd-854b562a359d)
