### PR TITLE
Fix Slice error on container.jsx

### DIFF
--- a/src/widgets/changedetectionio/component.jsx
+++ b/src/widgets/changedetectionio/component.jsx
@@ -16,7 +16,12 @@ export default function Component({ service }) {
   }
 
   if (!data) {
-    return <Container service={service} />;
+    return (
+      <Container service={service}>
+        <Block label="changedetectionio.diffsDetected" />
+        <Block label="changedetectionio.totalObserved" />
+      </Container>
+    );
   }
 
   const totalObserved = Object.keys(data).length;


### PR DESCRIPTION
## Proposed change

When a "changedetection.io" widget is visible on the screen, it caused an error, because while it was waiting for the API data, it returned a "Container" component without children, causing below.

![image](https://github.com/benphelps/homepage/assets/5890352/4ca60904-deb2-4fe3-a15c-89aa66e4fe80)

And now with this fix returns Block components as children without values.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
