### PR TITLE
error hostname:port/path was missing colon

### DIFF
--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -81,7 +81,7 @@ export async function httpProxy(url, params = {}) {
     return [status, contentType, data, responseHeaders];
   }
   catch (err) {
-    logger.error("Error calling %s//%s%s%s...", constructedUrl.protocol, constructedUrl.hostname, constructedUrl.port, constructedUrl.pathname);
+    logger.error("Error calling %s//%s:%s%s...", constructedUrl.protocol, constructedUrl.hostname, constructedUrl.port, constructedUrl.pathname);
     logger.error(err);
     return [500, "application/json", { error: {message: err?.message ?? "Unknown error", url, rawError: err} }, null];
   }


### PR DESCRIPTION
## Proposed change

Missing a colon between `host:port` in the error message.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
