### PR TITLE
Fix: Include backdrop classes in css build

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,4 +32,27 @@ module.exports = {
     },
   },
   plugins: [tailwindForms, tailwindScrollbars],
-};
+  // always include these in build as classes are dynamically constructed
+  safelist: [
+    'backdrop-blur',
+    'backdrop-blur-sm',
+    'backdrop-blur-md',
+    'backdrop-blur-xl',
+    'backdrop-saturate-0',
+    'backdrop-saturate-50',
+    'backdrop-saturate-100',
+    'backdrop-saturate-150',
+    'backdrop-saturate-200',
+    'backdrop-brightness-0',
+    'backdrop-brightness-50',
+    'backdrop-brightness-75',
+    'backdrop-brightness-90',
+    'backdrop-brightness-95',
+    'backdrop-brightness-100',
+    'backdrop-brightness-105',
+    'backdrop-brightness-110',
+    'backdrop-brightness-125',
+    'backdrop-brightness-150',
+    'backdrop-brightness-200',
+  ],
+}


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #1521

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
