### PR TITLE
Fix: background filters are not full height

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -359,6 +359,7 @@ export default function Wrapper({ initialSettings, fallback }) {
         <div
         id="inner_wrapper" 
         className={classNames(
+          'h-full',
           backgroundBlur && `backdrop-blur${initialSettings.background.blur.length ? '-' : ""}${initialSettings.background.blur}`,
           backgroundSaturate && `backdrop-saturate-${initialSettings.background.saturate}`,
           backgroundBrightness && `backdrop-brightness-${initialSettings.background.brightness}`,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

<img width="1840" alt="Screenshot 2023-05-20 at 2 42 17 AM" src="https://github.com/benphelps/homepage/assets/4887959/ad4ac1e3-2e4c-46b1-b55e-3036dab41f30">


Closes #1524 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
