### PR TITLE
feature: Add interactive Tasklist / Todo list

### DIFF
--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -33,5 +33,5 @@ export default function Container({ error = false, children, service }) {
     }));
   }
 
-  return <div className="relative flex flex-row w-full">{visibleChildren}</div>;
+  return <div className="relative flex flex-row w-full">{visibleChildren.slice(0, 4)}</div>;
 }

--- a/src/components/tasklist/group.jsx
+++ b/src/components/tasklist/group.jsx
@@ -1,0 +1,13 @@
+import ErrorBoundary from "components/errorboundry";
+import List from "components/tasklist/list";
+
+export default function TaskListGroup({ group }) {
+  return (
+    <div key={group.name} className="flex-1">
+      <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium">{group.name}</h2>
+      <ErrorBoundary>
+        <List tasklist={group.tasklist} />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/components/tasklist/group.jsx
+++ b/src/components/tasklist/group.jsx
@@ -1,12 +1,22 @@
+import { useState } from "react";
+
 import ErrorBoundary from "components/errorboundry";
 import List from "components/tasklist/list";
 
-export default function TaskListGroup({ group }) {
+export default function TaskListGroup({groupDetail, groupUpdate}) {
+  const [group, setGroup] = useState(groupDetail)
+  const groupName = Object.keys(group)[0]
+  const groupTasks = Object.values(group)[0]
+
+  const listUpdate = () => {
+    setGroup(group)
+    groupUpdate()
+  }
   return (
-    <div key={group.name} className="flex-1">
-      <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium">{group.name}</h2>
+    <div key={groupName} className="flex-1">
+      <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium">{groupName}</h2>
       <ErrorBoundary>
-        <List tasklist={group.tasklist} />
+        <List listDetail={groupTasks} listUpdate={listUpdate} />
       </ErrorBoundary>
     </div>
   );

--- a/src/components/tasklist/group.jsx
+++ b/src/components/tasklist/group.jsx
@@ -2,21 +2,40 @@ import { useState } from "react";
 
 import ErrorBoundary from "components/errorboundry";
 import List from "components/tasklist/list";
+import TaskBox from "components/tasklist/taskbox";
 
 export default function TaskListGroup({groupDetail, groupUpdate}) {
+  const [taskCount, setTaskCount] = useState(0)
   const [group, setGroup] = useState(groupDetail)
+
   const groupName = Object.keys(group)[0]
   const groupTasks = Object.values(group)[0]
+
+  const addTask = (value) => {
+    const newTask = {
+        title: value,
+        complete: false
+    };
+    groupTasks.push(newTask)
+
+    setGroup(group);
+    setTaskCount(groupTasks.length)
+    groupUpdate();
+  }
 
   const listUpdate = () => {
     setGroup(group)
     groupUpdate()
   }
+
   return (
-    <div key={groupName} className="flex-1">
+    <div key={taskCount} className="flex-1">
       <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium">{groupName}</h2>
       <ErrorBoundary>
         <List listDetail={groupTasks} listUpdate={listUpdate} />
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <TaskBox submitAction={addTask} />
       </ErrorBoundary>
     </div>
   );

--- a/src/components/tasklist/item.jsx
+++ b/src/components/tasklist/item.jsx
@@ -3,7 +3,7 @@ export default function Item({ task }) {
     <li key={task.title}>
       <div className="flex block w-full text-left transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10">
         <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md">
-          <input type="checkbox" className="bg-theme-500/10 text-sm font-medium rounded-l-m" id={task.title} checked={task.checked} readOnly/>
+          <input type="checkbox" className="checkbox bg-theme-500/10 text-theme-200 dark:text-theme-700" id={task.title} defaultChecked={task.checked}/>
         </div>
         <div className="flex-1 flex items-center justify-between rounded-r-md ">
           <div className="flex-1 grow pl-3 py-2 text-xs">{task.title}</div>

--- a/src/components/tasklist/item.jsx
+++ b/src/components/tasklist/item.jsx
@@ -4,7 +4,7 @@ export default function Item({taskDetail, taskUpdate}) {
   const [task, setTask] = useState(taskDetail)
 
   const toggleComplete = () => {
-    task.checked = !task.checked;
+    task.complete = !task.complete;
     setTask(task)
     taskUpdate()
   }
@@ -13,7 +13,7 @@ export default function Item({taskDetail, taskUpdate}) {
     <li key={task.title}>
       <div className="flex block w-full text-left transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10">
         <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md">
-          <input type="checkbox" className="checkbox bg-theme-500/10 text-theme-200 dark:text-theme-700" id={task.title} defaultChecked={task.checked} onChange={toggleComplete}/>
+          <input type="checkbox" className="checkbox bg-theme-500/10 text-theme-200 dark:text-theme-700" id={task.title} defaultChecked={task.complete} onChange={toggleComplete}/>
         </div>
         <div className="flex-1 flex items-center justify-between rounded-r-md ">
           <div className="flex-1 grow pl-3 py-2 text-xs">{task.title}</div>

--- a/src/components/tasklist/item.jsx
+++ b/src/components/tasklist/item.jsx
@@ -1,9 +1,19 @@
-export default function Item({ task }) {
+import {useState} from "react";
+
+export default function Item({taskDetail, taskUpdate}) {
+  const [task, setTask] = useState(taskDetail)
+
+  const toggleComplete = () => {
+    task.checked = !task.checked;
+    setTask(task)
+    taskUpdate()
+  }
+
   return (
     <li key={task.title}>
       <div className="flex block w-full text-left transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10">
         <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md">
-          <input type="checkbox" className="checkbox bg-theme-500/10 text-theme-200 dark:text-theme-700" id={task.title} defaultChecked={task.checked}/>
+          <input type="checkbox" className="checkbox bg-theme-500/10 text-theme-200 dark:text-theme-700" id={task.title} defaultChecked={task.checked} onChange={toggleComplete}/>
         </div>
         <div className="flex-1 flex items-center justify-between rounded-r-md ">
           <div className="flex-1 grow pl-3 py-2 text-xs">{task.title}</div>

--- a/src/components/tasklist/item.jsx
+++ b/src/components/tasklist/item.jsx
@@ -1,0 +1,14 @@
+export default function Item({ task }) {
+  return (
+    <li key={task.title}>
+      <div className="flex block w-full text-left transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10">
+        <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md">
+          <input type="checkbox" className="bg-theme-500/10 text-sm font-medium rounded-l-m" id={task.title} checked={task.checked} readOnly/>
+        </div>
+        <div className="flex-1 flex items-center justify-between rounded-r-md ">
+          <div className="flex-1 grow pl-3 py-2 text-xs">{task.title}</div>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/components/tasklist/list.jsx
+++ b/src/components/tasklist/list.jsx
@@ -1,10 +1,19 @@
+import { useState } from "react";
+
 import Item from "components/tasklist/item";
 
-export default function List({ tasklist }) {
+export default function List({listDetail, listUpdate}) {
+  const [tasks, setTasks] = useState(listDetail)
+
+  const taskUpdate = () => {
+    setTasks(tasks)
+    listUpdate()
+  }
+
   return (
     <ul className="mt-3 flex flex-col">
-      {tasklist.map((task) => (
-        <Item key={task.title} task={task} />
+      {tasks.map((task) => (
+        <Item key={Object.values(task)[0]} taskDetail={task} taskUpdate={taskUpdate} />
       ))}
     </ul>
   );

--- a/src/components/tasklist/list.jsx
+++ b/src/components/tasklist/list.jsx
@@ -1,0 +1,11 @@
+import Item from "components/tasklist/item";
+
+export default function List({ tasklist }) {
+  return (
+    <ul className="mt-3 flex flex-col">
+      {tasklist.map((task) => (
+        <Item key={task.title} task={task} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/tasklist/list.jsx
+++ b/src/components/tasklist/list.jsx
@@ -11,7 +11,7 @@ export default function List({listDetail, listUpdate}) {
   }
 
   return (
-    <ul className="mt-3 flex flex-col">
+    <ul key={tasks.length} className="mt-3 flex flex-col">
       {tasks.map((task) => (
         <Item key={Object.values(task)[0]} taskDetail={task} taskUpdate={taskUpdate} />
       ))}

--- a/src/components/tasklist/taskbox.jsx
+++ b/src/components/tasklist/taskbox.jsx
@@ -1,0 +1,22 @@
+import {useState} from "react";
+
+export default function TaskBox({submitAction}) {
+    // const [tasks, setTasks] = useState(listDetail)
+    const [formVal, setFormVal] = useState("")
+    // let inputValue = useRef(undefined)
+
+    const handleSubmit = (event) => {
+        // Stop the form from submitting and refreshing the page.
+        event.preventDefault();
+        submitAction(formVal);
+        setFormVal("");
+    }
+
+    return (
+        <div>
+            <form onSubmit={handleSubmit}>
+                <input type="text" id="title" name="title" value={formVal} placeholder="Add new task..." onChange={(e) => setFormVal(e.target.value)} />
+            </form>
+        </div>
+    );
+}

--- a/src/components/tasklist/taskbox.jsx
+++ b/src/components/tasklist/taskbox.jsx
@@ -13,9 +13,10 @@ export default function TaskBox({submitAction}) {
     }
 
     return (
-        <div>
-            <form onSubmit={handleSubmit}>
-                <input type="text" id="title" name="title" value={formVal} placeholder="Add new task..." onChange={(e) => setFormVal(e.target.value)} />
+        <div className="flex block w-full text-left transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10">
+            <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-l font-large rounded-l-md">+</div>
+            <form className="flex-1 flex items-center justify-between rounded-r-md " onSubmit={handleSubmit}>
+                <input type="text" className="textinput text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 flex-1 grow pl-3 py-2 text-xs" id="title" name="title" value={formVal} placeholder="Add new task..." onChange={(e) => setFormVal(e.target.value)} />
             </form>
         </div>
     );

--- a/src/pages/api/tasklist.js
+++ b/src/pages/api/tasklist.js
@@ -1,0 +1,5 @@
+import { tasklistResponse } from "utils/config/api-response";
+
+export default async function handler(req, res) {
+  res.send(await tasklistResponse());
+}

--- a/src/pages/api/tasklistSave.js
+++ b/src/pages/api/tasklistSave.js
@@ -1,0 +1,5 @@
+import { tasklistPersist } from "utils/config/api-response";
+
+export default async function handler(req, res) {
+  res.send(await tasklistPersist(req.body));
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,6 +10,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import ServicesGroup from "components/services/group";
 import BookmarksGroup from "components/bookmarks/group";
+import TasklistGroup from "components/tasklist/group";
 import Widget from "components/widgets/widget";
 import Revalidate from "components/toggles/revalidate";
 import createLogger from "utils/logger";
@@ -174,6 +175,7 @@ function Home({ initialSettings }) {
 
   const { data: services } = useSWR("/api/services");
   const { data: bookmarks } = useSWR("/api/bookmarks");
+  const { data: tasklist } = useSWR("/api/tasklist");
   const { data: widgets } = useSWR("/api/widgets");
 
   const servicesAndBookmarks = [...services.map(sg => sg.services).flat(), ...bookmarks.map(bg => bg.bookmarks).flat()]
@@ -290,6 +292,14 @@ function Home({ initialSettings }) {
           <div className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
             {services.map((group) => (
               <ServicesGroup key={group.name} services={group} layout={initialSettings.layout?.[group.name]} fiveColumns={settings.fiveColumns} />
+            ))}
+          </div>
+        )}
+
+        {tasklist?.length > 0 && (
+          <div className={`grow flex flex-wrap pt-0 p-4 sm:p-8 gap-2 grid-cols-1 lg:grid-cols-2 lg:grid-cols-${Math.min(6, tasklist.length)}`}>
+            {tasklist.map((group) => (
+              <TasklistGroup key={group.name} group={group} />
             ))}
           </div>
         )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -58,3 +58,7 @@ body {
 ::-webkit-details-marker {
   display: none;
 }
+
+.checkbox {
+  border-radius: 0.25em;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,3 +62,7 @@ body {
 .checkbox {
   border-radius: 0.25em;
 }
+
+.textinput {
+  border: none;
+}

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -54,19 +54,13 @@ export async function tasklistResponse() {
   const fileContents = substituteEnvironmentVars(rawFileContents);
   const tasklist = yaml.load(fileContents);
 
-  if (!tasklist) return [];
+  return tasklist
+}
 
-  // map easy to write YAML objects into easy to consume JS arrays
-  const tasklistArray = tasklist.map((group) => ({
-    name: Object.keys(group)[0],
-    tasklist: group[Object.keys(group)[0]].map((entries) => ({
-      // id: Object.values(entries)[0].replaceAll(" ", "_"),
-      title: Object.values(entries)[0],
-      checked: Object.values(entries)[1],
-    })),
-  }));
-
-  return tasklistArray;
+export async function tasklistPersist(taskState) {
+  const tasklistYaml = path.join(process.cwd(), "config", "tasklist.yaml");
+  await fs.writeFile(tasklistYaml, yaml.dump(JSON.parse(taskState)));
+  return [taskState];
 }
 
 export async function widgetsResponse() {

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -46,6 +46,29 @@ export async function bookmarksResponse() {
   return bookmarksArray;
 }
 
+export async function tasklistResponse() {
+  checkAndCopyConfig("tasklist.yaml");
+
+  const tasklistYaml = path.join(process.cwd(), "config", "tasklist.yaml");
+  const rawFileContents = await fs.readFile(tasklistYaml, "utf8");
+  const fileContents = substituteEnvironmentVars(rawFileContents);
+  const tasklist = yaml.load(fileContents);
+
+  if (!tasklist) return [];
+
+  // map easy to write YAML objects into easy to consume JS arrays
+  const tasklistArray = tasklist.map((group) => ({
+    name: Object.keys(group)[0],
+    tasklist: group[Object.keys(group)[0]].map((entries) => ({
+      // id: Object.values(entries)[0].replaceAll(" ", "_"),
+      title: Object.values(entries)[0],
+      checked: Object.values(entries)[1],
+    })),
+  }));
+
+  return tasklistArray;
+}
+
 export async function widgetsResponse() {
   let configuredWidgets;
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

This adds a new entry to the Homepage to allow users to start a task list from a YAML file (`tasklist.yaml`) and allow updates to add tasks and "complete" tasks by checking a checkbox. Changes are persisted back to the YAML file

I am not a frontend developer, but I tried to follow the same practices. This is based on the Bookmarks code, so will behave in a similar fashion. I may have gone over-the-top on `className`s to get the styling right.

Please give any feedback on this

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
