### PR TITLE
Enhanced glances widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -315,10 +315,14 @@
     },
     "glances": {
         "cpu": "CPU",
-        "mem": "MEM",
+        "load": "Load",
         "wait": "Please wait",
         "temp": "TEMP",
+        "warn": "Warn",
         "uptime": "UP",
+        "total": "Total",
+        "free": "Free",
+        "used": "Used",
         "days": "d",
         "hours": "h"
     },

--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -1,10 +1,13 @@
 import useSWR from "swr";
+import { useContext } from "react";
 import { BiError } from "react-icons/bi";
 import { FaMemory, FaRegClock, FaThermometerHalf } from "react-icons/fa";
 import { FiCpu, FiHardDrive } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
 
 import UsageBar from "../resources/usage-bar";
+
+import { SettingsContext } from "utils/contexts/settings";
 
 const cpuSensorLabels = ["cpu_thermal", "Core", "Tctl"];
 
@@ -14,6 +17,7 @@ function convertToFahrenheit(t) {
 
 export default function Widget({ options }) {
   const { t, i18n } = useTranslation();
+  const { settings } = useContext(SettingsContext);
 
   const { data, error } = useSWR(
     `/api/widgets/glances?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`, {
@@ -93,7 +97,7 @@ export default function Widget({ options }) {
     : [data.fs.find((d) => d.mnt_point === options.disk)].filter((d) => d);
 
   return (
-    <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap">
+    <a href={options.url} target={settings.target ?? "_blank"} className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap">
       <div className="flex flex-row self-center flex-wrap justify-between">
          <div className="flex-none flex flex-row items-center mr-3 py-1.5">
           <FiCpu className="text-theme-800 dark:text-theme-200 w-5 h-5" />
@@ -218,6 +222,6 @@ export default function Widget({ options }) {
       {options.label && (
         <div className="pt-1 text-center text-theme-800 dark:text-theme-200 text-xs">{options.label}</div>
       )}
-    </div>
+    </a>
   );
 }

--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -92,9 +92,13 @@ export default function Widget({ options }) {
   }
   const tempPercent = Math.round((mainTemp / maxTemp) * 100);
 
-  const disks = Array.isArray(options.disk)
-    ? options.disk.map((disk) => data.fs.find((d) => d.mnt_point === disk)).filter((d) => d)
-    : [data.fs.find((d) => d.mnt_point === options.disk)].filter((d) => d);
+  let disks = [];
+
+  if (options.disk) {
+    disks = Array.isArray(options.disk)
+      ? options.disk.map((disk) => data.fs.find((d) => d.mnt_point === disk)).filter((d) => d)
+      : [data.fs.find((d) => d.mnt_point === options.disk)].filter((d) => d);
+  }
 
   return (
     <a href={options.url} target={settings.target ?? "_blank"} className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap">
@@ -157,7 +161,7 @@ export default function Widget({ options }) {
             <UsageBar percent={data.mem.percent} />
           </div>
         </div>
-        {options.disk && disks.map((disk) => (
+        {disks.map((disk) => (
           <div key={disk.mnt_point} className="flex-none flex flex-row items-center mr-3 py-1.5">
             <FiHardDrive className="text-theme-800 dark:text-theme-200 w-5 h-5" />
             <div className="flex flex-col ml-3 text-left min-w-[85px]">

--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { BiError } from "react-icons/bi";
 import { FaMemory, FaRegClock, FaThermometerHalf } from "react-icons/fa";
-import { FiCpu } from "react-icons/fi";
+import { FiCpu, FiHardDrive } from "react-icons/fi";
 import { useTranslation } from "next-i18next";
 
 import UsageBar from "../resources/usage-bar";
@@ -88,8 +88,12 @@ export default function Widget({ options }) {
   }
   const tempPercent = Math.round((mainTemp / maxTemp) * 100);
 
+  const disks = Array.isArray(options.disk)
+    ? options.disk.map((disk) => data.fs.find((d) => d.mnt_point === disk)).filter((d) => d)
+    : [data.fs.find((d) => d.mnt_point === options.disk)].filter((d) => d);
+
   return (
-    <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap ml-4">
+    <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap">
       <div className="flex flex-row self-center flex-wrap justify-between">
          <div className="flex-none flex flex-row items-center mr-3 py-1.5">
           <FiCpu className="text-theme-800 dark:text-theme-200 w-5 h-5" />
@@ -97,7 +101,7 @@ export default function Widget({ options }) {
             <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
               <div className="pl-0.5">
                 {t("common.number", {
-                  value: data.quicklook.cpu,
+                  value: data.cpu.total,
                   style: "unit",
                   unit: "percent",
                   maximumFractionDigits: 0,
@@ -105,7 +109,20 @@ export default function Widget({ options }) {
               </div>
               <div className="pr-1">{t("glances.cpu")}</div>
             </div>
-            <UsageBar percent={data.quicklook.cpu} />
+            {options.expanded && (
+              <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                <div className="pl-0.5 pr-1">
+                {t("common.number", {
+                  value: data.load.min15,
+                  style: "unit",
+                  unit: "percent",
+                  maximumFractionDigits: 0,
+                })}
+                </div>
+                <div className="pr-1">{t("glances.load")}</div>
+              </span>
+            )}
+            <UsageBar percent={data.cpu.total} />
           </div>
         </div>
         <div className="flex-none flex flex-row items-center mr-3 py-1.5">
@@ -113,18 +130,46 @@ export default function Widget({ options }) {
           <div className="flex flex-col ml-3 text-left min-w-[85px]">
             <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
               <div className="pl-0.5">
-                {t("common.number", {
-                  value: data.quicklook.mem,
-                  style: "unit",
-                  unit: "percent",
-                  maximumFractionDigits: 0,
+                {t("common.bytes", {
+                  value: data.mem.free,
+                  maximumFractionDigits: 1,
+                  binary: true,
                 })}
               </div>
-              <div className="pr-1">{t("glances.mem")}</div>
+              <div className="pr-1">{t("glances.free")}</div>
             </div>
-            <UsageBar percent={data.quicklook.mem} />
+            {options.expanded && (
+              <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                <div className="pl-0.5 pr-1">
+                  {t("common.bytes", {
+                    value: data.mem.total,
+                    maximumFractionDigits: 1,
+                    binary: true,
+                  })}
+                </div>
+                <div className="pr-1">{t("glances.total")}</div>
+              </span>
+            )}
+            <UsageBar percent={data.mem.percent} />
           </div>
         </div>
+        {options.disk && disks.map((disk) => (
+          <div key={disk.mnt_point} className="flex-none flex flex-row items-center mr-3 py-1.5">
+            <FiHardDrive className="text-theme-800 dark:text-theme-200 w-5 h-5" />
+            <div className="flex flex-col ml-3 text-left min-w-[85px]">
+              <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                <div className="pl-0.5">{t("common.bytes", { value: disk.free })}</div>
+                <div className="pr-1">{t("glances.free")}</div>
+              </span>
+              {options.expanded && (
+                <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                  <div className="pl-0.5 pr-1">{t("common.bytes", { value: disk.size })}</div>
+                  <div className="pr-1">{t("glances.total")}</div>
+                </span>
+              )}
+              <UsageBar percent={disk.percent} />
+            </div>
+          </div>))}
         {options.cputemp && mainTemp > 0 &&
             (<div className="flex-none flex flex-row items-center mr-3 py-1.5">
             <FaThermometerHalf className="text-theme-800 dark:text-theme-200 w-5 h-5" />
@@ -140,6 +185,19 @@ export default function Widget({ options }) {
                 </div>
                 <div className="pr-1">{t("glances.temp")}</div>
               </span>
+              {options.expanded && (
+                <span className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+                  <div className="pl-0.5 pr-1">
+                  {t("common.number", { 
+                    value: maxTemp,
+                    maximumFractionDigits: 1,
+                    style: "unit",
+                    unit
+                  })}
+                  </div>
+                  <div className="pr-1">{t("glances.warn")}</div>
+                </span>
+              )}
               <UsageBar percent={tempPercent} />
             </div>
           </div>)}

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -40,25 +40,31 @@ async function retrieveFromGlancesAPI(privateWidgetOptions, endpoint) {
 }
 
 export default async function handler(req, res) {
-  const { index } = req.query;
+  const { index, cputemp: includeCpuTemp, uptime: includeUptime, disk: includeDisks } = req.query;
 
   const privateWidgetOptions = await getPrivateWidgetOptions("glances", index);
 
   try {
     const cpuData = await retrieveFromGlancesAPI(privateWidgetOptions, "cpu");
     const loadData = await retrieveFromGlancesAPI(privateWidgetOptions, "load");
-    const uptimeData = await retrieveFromGlancesAPI(privateWidgetOptions, "uptime");
-    const sensorData = await retrieveFromGlancesAPI(privateWidgetOptions, "sensors");
     const memoryData = await retrieveFromGlancesAPI(privateWidgetOptions, "mem");
-    const filesystemData = await retrieveFromGlancesAPI(privateWidgetOptions, "fs");
-
     const data = {
       cpu: cpuData,
       load: loadData,
-      uptime: uptimeData,
-      sensors: sensorData,
       mem: memoryData,
-      fs: filesystemData,
+    }
+
+    // Disabled by default, dont call unless needed
+    if (includeUptime) {
+      data.uptime = await retrieveFromGlancesAPI(privateWidgetOptions, "uptime");
+    }
+
+    if (includeCpuTemp) {
+      data.sensors = await retrieveFromGlancesAPI(privateWidgetOptions, "sensors");
+    }
+
+    if (includeDisks) {
+      data.fs = await retrieveFromGlancesAPI(privateWidgetOptions, "fs");
     }
 
     return res.status(200).send(data);

--- a/src/pages/api/widgets/glances.js
+++ b/src/pages/api/widgets/glances.js
@@ -45,15 +45,21 @@ export default async function handler(req, res) {
   const privateWidgetOptions = await getPrivateWidgetOptions("glances", index);
 
   try {
-    const quicklookData = await retrieveFromGlancesAPI(privateWidgetOptions, "quicklook");
+    const cpuData = await retrieveFromGlancesAPI(privateWidgetOptions, "cpu");
+    const loadData = await retrieveFromGlancesAPI(privateWidgetOptions, "load");
+    const uptimeData = await retrieveFromGlancesAPI(privateWidgetOptions, "uptime");
+    const sensorData = await retrieveFromGlancesAPI(privateWidgetOptions, "sensors");
+    const memoryData = await retrieveFromGlancesAPI(privateWidgetOptions, "mem");
+    const filesystemData = await retrieveFromGlancesAPI(privateWidgetOptions, "fs");
 
     const data = {
-      quicklook: quicklookData
+      cpu: cpuData,
+      load: loadData,
+      uptime: uptimeData,
+      sensors: sensorData,
+      mem: memoryData,
+      fs: filesystemData,
     }
-    
-    data.uptime = await retrieveFromGlancesAPI(privateWidgetOptions, "uptime");
-    
-    data.sensors = await retrieveFromGlancesAPI(privateWidgetOptions, "sensors");
 
     return res.status(200).send(data);
   } catch (e) {

--- a/src/utils/config/widget-helpers.js
+++ b/src/utils/config/widget-helpers.js
@@ -5,8 +5,6 @@ import yaml from "js-yaml";
 
 import checkAndCopyConfig, { substituteEnvironmentVars } from "utils/config/config";
 
-const exemptWidgets = ["search"];
-
 export async function widgetsFromConfig() {
     checkAndCopyConfig("widgets.yaml");
 
@@ -32,15 +30,17 @@ export async function cleanWidgetGroups(widgets) {
     return widgets.map((widget, index) => {
         const sanitizedOptions = widget.options;
         const optionKeys = Object.keys(sanitizedOptions);
-        if (!exemptWidgets.includes(widget.type)) {
-            ["url", "username", "password", "key"].forEach((pO) => { 
-                if (optionKeys.includes(pO)) {
-                    // allow URL in search
-                    if (widget.type !== "search" && pO !== "key") {
-                        delete sanitizedOptions[pO];
-                    }
-                }
-            });
+        
+        // delete private options from the sanitized options
+        ["username", "password", "key"].forEach((pO) => { 
+            if (optionKeys.includes(pO)) {
+                delete sanitizedOptions[pO];
+            }
+        });
+        
+        // delete url from the sanitized options if the widget is not a search or glances widgeth
+        if (widget.type !== "search" && widget.type !== "glances" && optionKeys.includes("url")) {
+            delete sanitizedOptions.url;
         }
 
         return {


### PR DESCRIPTION
## Proposed change

Enhance the glances widget to include the ability to display disk(s) and mirror the style and structure of the resource widget.

Closes #672 

<img width="683" alt="235331114-69b2dc0b-4d2e-4ec4-91e3-db5ac66ce621" src="https://github.com/benphelps/homepage/assets/3247106/f5373832-3d76-4052-94d6-1211814211b7">

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/104
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`. ✔ No ESLint warnings or errors
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
