### PR TITLE
Correctly use sys_tempc instead of cpu_tempc in QNAP widget

### DIFF
--- a/src/widgets/qnap/component.jsx
+++ b/src/widgets/qnap/component.jsx
@@ -31,7 +31,7 @@ export default function Component({ service }) {
   const cpuUsage = statusData.system.cpu_usage._cdata.replace(' %','');
   const totalMemory = statusData.system.total_memory._cdata;
   const freeMemory = statusData.system.free_memory._cdata;
-  const systemTempC = statusData.system.cpu_tempc._text;
+  const systemTempC = statusData.system.sys_tempc._text;
   let volumeTotalSize = 0;
   let volumeFreeSize = 0;
   let validVolume = true;


### PR DESCRIPTION
## Proposed change

Some what noted by @ToqQrrlin a comment on https://github.com/benphelps/homepage/pull/1470#issuecomment-1556388243 I had used CPU temp, when I should have system temp.

CPU temp is also not available in older QNAPs.

This pull request switches to using the correct temperature sensor to match the system temp output.

Closes # (issue)
https://github.com/benphelps/homepage/pull/1470#issuecomment-1556388243
## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
