### PR TITLE
Fix: support using docker labels for HASS widget custom

### DIFF
--- a/src/widgets/homeassistant/proxy.js
+++ b/src/widgets/homeassistant/proxy.js
@@ -71,6 +71,14 @@ export default async function homeassistantProxyHandler(req, res) {
   
   let queries = defaultQueries;
   if (!widget.fields && widget.custom) {
+    if (typeof widget.custom === 'string') {
+      try {
+        widget.custom = JSON.parse(widget.custom)
+      } catch (error) {
+        logger.debug("Error parsing HASS widget custom label: %s", JSON.stringify(error));
+        return res.status(400).json({ error: "Error parsing widget custom label" });
+      }
+    }
     queries = widget.custom.slice(0, 4);
   }
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

See 

E.g. 
```
homepage.widget.custom=[{"template":"{{states.cover|selectattr('state','equalto','closed')|list|length}}/{{states.cover|list|length}}","label":"Garage Doors"},{"state":"alarm_control_panel.alarm_control_panel","label":"Alarm System"}]
```

<img width="374" alt="Screenshot 2023-05-25 at 11 11 46 PM" src="https://github.com/benphelps/homepage/assets/4887959/35ee466a-034c-478d-b848-d70ee091c34e">


Closes #1544

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
