### PR TITLE
Enhancement: support settings layout as a list

### DIFF
--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -65,5 +65,20 @@ export function getSettings() {
   const settingsYaml = join(process.cwd(), "config", "settings.yaml");
   const rawFileContents = readFileSync(settingsYaml, "utf8");
   const fileContents = substituteEnvironmentVars(rawFileContents);
-  return yaml.load(fileContents) ?? {};
+  const initialSettings = yaml.load(fileContents) ?? {};
+
+  if (initialSettings.layout) {
+    // support yaml list but old spec was object so convert to that
+    // see https://github.com/benphelps/homepage/issues/1546
+    if (Array.isArray(initialSettings.layout)) {
+      const layoutItems = initialSettings.layout
+      initialSettings.layout = {}
+      layoutItems.forEach(i => {
+        const name = Object.keys(i)[0]
+        initialSettings.layout[name] = i[name]
+      })
+    }
+  }
+
+  return initialSettings
 }


### PR DESCRIPTION
## Proposed change

See linked issue. Should be backwards compatible

New syntax is e.g., I'll update the docs:

```yaml
layout:
  - Group1:
  - Group2:
  - Group3:
      style: row
      columns: 3
```

Closes #1546

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
