### PR TITLE
Fix: Handle k8s widget metrics call fails

### DIFF
--- a/src/pages/api/widgets/kubernetes.js
+++ b/src/pages/api/widgets/kubernetes.js
@@ -52,18 +52,25 @@ export default async function handler(req, res) {
       memTotal += mem;
     });
 
-    const nodeMetrics = await metricsApi.getNodeMetrics();
-    nodeMetrics.items.forEach((nodeMetric) => {
-      const cpu = parseCpu(nodeMetric.usage.cpu);
-      const mem = parseMemory(nodeMetric.usage.memory);
-      cpuUsage += cpu;
-      memUsage += mem;
-      nodeMap[nodeMetric.metadata.name].cpu.load = cpu;
-      nodeMap[nodeMetric.metadata.name].cpu.percent = (cpu / nodeMap[nodeMetric.metadata.name].cpu.total) * 100;
-      nodeMap[nodeMetric.metadata.name].memory.used = mem;
-      nodeMap[nodeMetric.metadata.name].memory.free = nodeMap[nodeMetric.metadata.name].memory.total - mem;
-      nodeMap[nodeMetric.metadata.name].memory.percent = (mem / nodeMap[nodeMetric.metadata.name].memory.total) * 100;
-    });
+    try {
+      const nodeMetrics = await metricsApi.getNodeMetrics();
+      nodeMetrics.items.forEach((nodeMetric) => {
+        const cpu = parseCpu(nodeMetric.usage.cpu);
+        const mem = parseMemory(nodeMetric.usage.memory);
+        cpuUsage += cpu;
+        memUsage += mem;
+        nodeMap[nodeMetric.metadata.name].cpu.load = cpu;
+        nodeMap[nodeMetric.metadata.name].cpu.percent = (cpu / nodeMap[nodeMetric.metadata.name].cpu.total) * 100;
+        nodeMap[nodeMetric.metadata.name].memory.used = mem;
+        nodeMap[nodeMetric.metadata.name].memory.free = nodeMap[nodeMetric.metadata.name].memory.total - mem;
+        nodeMap[nodeMetric.metadata.name].memory.percent = (mem / nodeMap[nodeMetric.metadata.name].memory.total) * 100;
+      });
+    } catch (error) {
+      logger.error("Error getting metrics, ensure you have metrics-server installed: s", JSON.stringify(error));
+      return res.status(500).send({
+        error: "Error getting metrics, check logs for more details"
+      });
+    }
 
     const cluster = {
       cpu: {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #1415

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
