### PR TITLE
Enhancement: substitute environment vars in container labels

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -86,7 +86,7 @@ export async function servicesFromDocker() {
                   type: 'service'
                 };
               }
-              shvl.set(constructedService, label.replace("homepage.", ""), container.Labels[label]);
+              shvl.set(constructedService, label.replace("homepage.", ""), substituteEnvironmentVars(container.Labels[label]));
             }
           });
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -175,7 +175,7 @@ export async function servicesFromKubernetes() {
     const services = ingressList.items
       .filter((ingress) => ingress.metadata.annotations && ingress.metadata.annotations[`${ANNOTATION_BASE}/enabled`] === 'true')
       .map((ingress) => {
-      const constructedService = {
+      let constructedService = {
         app: ingress.metadata.name,
         namespace: ingress.metadata.namespace,
         href: ingress.metadata.annotations[`${ANNOTATION_BASE}/href`] || getUrlFromIngress(ingress),
@@ -201,6 +201,12 @@ export async function servicesFromKubernetes() {
           shvl.set(constructedService, annotation.replace(`${ANNOTATION_BASE}/`, ""), ingress.metadata.annotations[annotation]);
         }
       });
+
+      try {
+        constructedService = JSON.parse(substituteEnvironmentVars(JSON.stringify(constructedService)));
+      } catch (e) {
+        logger.error("Error attempting k8s environment variable substitution.");
+      }
 
       return constructedService;
     });


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->
Docker services with dynamic labels that have environment vars like HOMEPAGE_VARS_XXX and HOMEPAGE_FILE_XXX are not parsed currently. This ensures all labels are checked for applicable replacements.

~~NOTE: This bug likely still exists in the Kubernetes function. I do not have a Kubernetes environment to test with.~~

Closes #1553 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
