### PR TITLE
Feature/sonarr radarr queue list

### DIFF
--- a/src/components/services/widget/block-list.jsx
+++ b/src/components/services/widget/block-list.jsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "next-i18next";
+import { useCallback, useState } from 'react';
+import classNames from "classnames";
+
+import ResolvedIcon from '../../resolvedicon';
+
+
+export default function BlockList({ label, children, childHeight }) {
+  const { t } = useTranslation();
+  const [isOpen, setOpen] = useState(false);
+
+  const changeState = useCallback(() => setOpen(!isOpen), [isOpen, setOpen]);
+
+  return (
+    <div
+      className={classNames(
+        "bg-theme-200/50 dark:bg-theme-900/20 rounded m-1 w-full p-1",
+        children === undefined ? "animate-pulse" : ""
+      )}>
+      <button type="button" onClick={changeState} className="w-full flex-1 flex flex-col items-center justify-center text-center">
+        <div className="font-bold text-xs uppercase">{t(label)}</div>
+        <ResolvedIcon icon={isOpen ? "mdi-chevron-down" : "mdi-chevron-up"} />
+      </button>
+      <div
+        className="w-full flex-1 flex flex-col items-center justify-center text-center overflow-hidden transition-height duration-500"
+        style={{height: isOpen ? childHeight * (children?.length ?? 1) : 0}}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -15,7 +15,9 @@ export default function Container({ error = false, children, service }) {
     return <Error service={service} error={error} />
   }
 
-  let visibleChildren = children;
+  const childrenArray = Array.isArray(children) ? children : [children];
+
+  let visibleChildren = childrenArray;
   const fields = service?.widget?.fields;
   const type = service?.widget?.type;
   if (fields && type) {
@@ -24,7 +26,7 @@ export default function Container({ error = false, children, service }) {
     // fields: [ "resources.cpu", "resources.mem", "field"]
     // or even
     // fields: [ "resources.cpu", "widget_type.field" ]
-    visibleChildren = children?.filter(child => fields.some(field => {
+    visibleChildren = childrenArray?.filter(child => fields.some(field => {
       let fullField = field;
       if (!field.includes(".")) {
         fullField = `${type}.${field}`;

--- a/src/widgets/radarr/component.jsx
+++ b/src/widgets/radarr/component.jsx
@@ -1,7 +1,10 @@
 import { useTranslation } from "next-i18next";
+import { useCallback } from 'react';
+import classNames from 'classnames';
 
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
+import BlockList from "components/services/widget/block-list";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
@@ -10,29 +13,75 @@ export default function Component({ service }) {
 
   const { data: moviesData, error: moviesError } = useWidgetAPI(widget, "movie");
   const { data: queuedData, error: queuedError } = useWidgetAPI(widget, "queue/status");
+  const { data: queueDetailsData, error: queueDetailsError } = useWidgetAPI(widget, "queue/details");
 
-  if (moviesError || queuedError) {
-    const finalError = moviesError ?? queuedError;
+  // information taken from the Radarr docs: https://radarr.video/docs/api/
+  const formatDownloadState = useCallback((downloadState) => {
+    switch (downloadState) {
+      case "importPending":
+        return "import pending";
+      case "failedPending":
+        return "failed pending";
+      default:
+        return downloadState;
+    }
+  }, []);
+
+  if (moviesError || queuedError || queueDetailsError) {
+    const finalError = moviesError ?? queuedError ?? queueDetailsError;
     return <Container service={service} error={finalError} />;
   }
 
-  if (!moviesData || !queuedData) {
+  if (!moviesData || !queuedData || !queueDetailsData) {
     return (
-      <Container service={service}>
-        <Block label="radarr.wanted" />
-        <Block label="radarr.missing" />
-        <Block label="radarr.queued" />
-        <Block label="radarr.movies" />
-      </Container>
+      <>
+        <Container service={service}>
+          <Block label="radarr.wanted" />
+          <Block label="radarr.missing" />
+          <Block label="radarr.queued" />
+          <Block label="radarr.movies" />
+        </Container>
+        <Container service={service}>
+          <BlockList label="radarr.queued" />
+        </Container>
+      </>
     );
   }
 
   return (
-    <Container service={service}>
-      <Block label="radarr.wanted" value={t("common.number", { value: moviesData.wanted })} />
-      <Block label="radarr.missing" value={t("common.number", { value: moviesData.missing })} />
-      <Block label="radarr.queued" value={t("common.number", { value: queuedData.totalCount })} />
-      <Block label="radarr.movies" value={t("common.number", { value: moviesData.have })} />
-    </Container>
+    <>
+      <Container service={service}>
+        <Block label="radarr.wanted" value={t("common.number", { value: moviesData.wanted })} />
+        <Block label="radarr.missing" value={t("common.number", { value: moviesData.missing })} />
+        <Block label="radarr.queued" value={t("common.number", { value: queuedData.totalCount })} />
+        <Block label="radarr.movies" value={t("common.number", { value: moviesData.have })} />
+      </Container>
+      <Container service={service}>
+        <BlockList label="radarr.queued" childHeight={52}>
+          {Array.isArray(queueDetailsData) ? queueDetailsData.map((queueEntry) => (
+            <div className="my-0.5 w-full flex flex-col justify-between items-center" key={queueEntry.movieId}>
+              <div className="h-6 w-full flex flex-row justify-between items-center">
+                <div className="overflow-ellipsis whitespace-nowrap overflow-hidden w-3/4 text-left">{moviesData.all.find((entry) => entry.id === queueEntry.movieId)?.title}</div>
+                <div>{formatDownloadState(queueEntry.trackedDownloadState)}</div>
+              </div>
+              <div className="h-6 w-full flex flex-row justify-between items-center">
+                <div className="mr-5 w-full bg-theme-800/30 rounded-full h-full dark:bg-theme-200/20">
+                  <div
+                    className={classNames(
+                      "h-full rounded-full transition-all duration-1000",
+                      queueEntry.trackedDownloadStatus === "ok" ? "bg-blue-500/80" : "bg-orange-500/80"
+                    )}
+                    style={{
+                      width: `${(1 - queueEntry.sizeLeft / queueEntry.size) * 100}%`,
+                    }}
+                  />
+                </div>
+                <div className="w-24 text-right">{queueEntry.timeLeft}</div>
+              </div>
+            </div>
+          )) : undefined}
+        </BlockList>
+      </Container>
+    </>
   );
 }

--- a/src/widgets/radarr/component.jsx
+++ b/src/widgets/radarr/component.jsx
@@ -61,7 +61,9 @@ export default function Component({ service }) {
           {Array.isArray(queueDetailsData) ? queueDetailsData.map((queueEntry) => (
             <div className="my-0.5 w-full flex flex-col justify-between items-center" key={queueEntry.movieId}>
               <div className="h-6 w-full flex flex-row justify-between items-center">
-                <div className="overflow-ellipsis whitespace-nowrap overflow-hidden w-3/4 text-left">{moviesData.all.find((entry) => entry.id === queueEntry.movieId)?.title}</div>
+                <div className="w-full mr-5 overflow-hidden">
+                  <div className="whitespace-nowrap w-0 text-left">{moviesData.all.find((entry) => entry.id === queueEntry.movieId)?.title}</div>
+                </div>
                 <div>{formatDownloadState(queueEntry.trackedDownloadState)}</div>
               </div>
               <div className="h-6 w-full flex flex-row justify-between items-center">

--- a/src/widgets/sonarr/component.jsx
+++ b/src/widgets/sonarr/component.jsx
@@ -60,7 +60,9 @@ export default function Component({ service }) {
           {Array.isArray(queueDetailsData) ? queueDetailsData.map((queueEntry) => (
             <div className="my-0.5 w-full flex flex-col justify-between items-center" key={queueEntry.episodeId}>
               <div className="h-6 w-full flex flex-row justify-between items-center">
-                <div className="overflow-ellipsis whitespace-nowrap overflow-hidden w-3/4 text-left">{seriesData.find((entry) => entry.id === queueEntry.seriesId).title} • {queueEntry.episodeTitle}</div>
+                <div className="w-full mr-5 overflow-hidden">
+                  <div className="whitespace-nowrap text-left w-0">{seriesData.find((entry) => entry.id === queueEntry.seriesId).title} • {queueEntry.episodeTitle}</div>
+                </div>
                 <div>{formatDownloadState(queueEntry.trackedDownloadState)}</div>
               </div>
               <div className="h-6 w-full flex flex-row justify-between items-center">

--- a/src/widgets/sonarr/component.jsx
+++ b/src/widgets/sonarr/component.jsx
@@ -1,8 +1,11 @@
 import { useTranslation } from "next-i18next";
+import classNames from 'classnames';
+import { useCallback } from 'react';
 
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
+import BlockList from 'components/services/widget/block-list';
 
 export default function Component({ service }) {
   const { t } = useTranslation();
@@ -11,27 +14,73 @@ export default function Component({ service }) {
   const { data: wantedData, error: wantedError } = useWidgetAPI(widget, "wanted/missing");
   const { data: queuedData, error: queuedError } = useWidgetAPI(widget, "queue");
   const { data: seriesData, error: seriesError } = useWidgetAPI(widget, "series");
+  const { data: queueDetailsData, error: queueDetailsError } = useWidgetAPI(widget, "queue/details");
 
-  if (wantedError || queuedError || seriesError) {
-    const finalError = wantedError ?? queuedError ?? seriesError;
+  // information taken from the Sonarr docs: https://sonarr.tv/docs/api/
+  const formatDownloadState = useCallback((downloadState) => {
+    switch (downloadState) {
+      case "importPending":
+        return "import pending";
+      case "failedPending":
+        return "failed pending";
+      default:
+        return downloadState;
+    }
+  }, []);
+
+  if (wantedError || queuedError || seriesError || queueDetailsError) {
+    const finalError = wantedError ?? queuedError ?? seriesError ?? queueDetailsError;
     return <Container service={service} error={finalError} />;
   }
 
-  if (!wantedData || !queuedData || !seriesData) {
+  if (!wantedData || !queuedData || !seriesData || !queueDetailsData) {
     return (
-      <Container service={service}>
-        <Block label="sonarr.wanted" />
-        <Block label="sonarr.queued" />
-        <Block label="sonarr.series" />
-      </Container>
+      <>
+        <Container service={service}>
+          <Block label="sonarr.wanted" />
+          <Block label="sonarr.queued" />
+          <Block label="sonarr.series" />
+        </Container>
+        <Container service={service}>
+          <BlockList label="sonarr.queued" />
+        </Container>
+      </>
     );
   }
 
   return (
-    <Container service={service}>
-      <Block label="sonarr.wanted" value={t("common.number", { value: wantedData.totalRecords })} />
-      <Block label="sonarr.queued" value={t("common.number", { value: queuedData.totalRecords })} />
-      <Block label="sonarr.series" value={t("common.number", { value: seriesData.total })} />
-    </Container>
+    <>
+      <Container service={service}>
+        <Block label="sonarr.wanted" value={t("common.number", { value: wantedData.totalRecords })} />
+        <Block label="sonarr.queued" value={t("common.number", { value: queuedData.totalRecords })} />
+        <Block label="sonarr.series" value={t("common.number", { value: seriesData.length })} />
+      </Container>
+      <Container service={service}>
+        <BlockList label="sonarr.queued" childHeight={52}>
+          {Array.isArray(queueDetailsData) ? queueDetailsData.map((queueEntry) => (
+            <div className="my-0.5 w-full flex flex-col justify-between items-center" key={queueEntry.episodeId}>
+              <div className="h-6 w-full flex flex-row justify-between items-center">
+                <div className="overflow-ellipsis whitespace-nowrap overflow-hidden w-3/4 text-left">{seriesData.find((entry) => entry.id === queueEntry.seriesId).title} • {queueEntry.episodeTitle}</div>
+                <div>{formatDownloadState(queueEntry.trackedDownloadState)}</div>
+              </div>
+              <div className="h-6 w-full flex flex-row justify-between items-center">
+                <div className="mr-5 w-full bg-theme-800/30 rounded-full h-full dark:bg-theme-200/20">
+                  <div
+                    className={classNames(
+                      "h-full rounded-full transition-all duration-1000",
+                      queueEntry.trackedDownloadStatus === "ok" ? "bg-blue-500/80" : "bg-orange-500/80"
+                    )}
+                    style={{
+                      width: `${(1 - queueEntry.sizeLeft / queueEntry.size) * 100}%`,
+                    }}
+                  />
+                </div>
+                <div className="w-24 text-right">{queueEntry.timeLeft}</div>
+              </div>
+            </div>
+          )) : undefined}
+        </BlockList>
+      </Container>
+    </>
   );
 }

--- a/src/widgets/sonarr/widget.js
+++ b/src/widgets/sonarr/widget.js
@@ -8,9 +8,10 @@ const widget = {
   mappings: {
     series: {
       endpoint: "series",
-      map: (data) => ({
-        total: asJson(data).length,
-      })
+      map: (data) => asJson(data).map((entry) => ({
+        title: entry.title,
+        id: entry.id
+      }))
     },
     queue: {
       endpoint: "queue",
@@ -24,6 +25,38 @@ const widget = {
         "totalRecords"
       ]
     },
+    "queue/details": {
+      endpoint: "queue/details",
+      map: (data) => asJson(data).map((entry) => ({
+        trackedDownloadState: entry.trackedDownloadState,
+        trackedDownloadStatus: entry.trackedDownloadStatus,
+        timeLeft: entry.timeleft,
+        size: entry.size,
+        sizeLeft: entry.sizeleft,
+        seriesId: entry.seriesId,
+        episodeTitle: entry.episode?.title,
+        episodeId: entry.episodeId
+      })).sort((a, b) => {
+        const downloadingA = a.trackedDownloadState === "downloading"
+        const downloadingB = b.trackedDownloadState === "downloading"
+        if (downloadingA && !downloadingB) {
+          return -1;
+        }
+        if (downloadingB && !downloadingA) {
+          return 1;
+        }
+
+        const percentA = a.sizeLeft / a.size;
+        const percentB = b.sizeLeft / b.size;
+        if (percentA < percentB) {
+          return -1;
+        }
+        if (percentA > percentB) {
+          return 1;
+        }
+        return 0;
+      })
+    }
   },
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,9 @@ module.exports = {
         '3xl': '1800px',
         // => @media (min-width: 1800px) { ... }
       },
+      transitionProperty: {
+        'height': 'height'
+      },
     },
   },
   plugins: [tailwindForms, tailwindScrollbars],


### PR DESCRIPTION
## Proposed change

I have added a simple queue-list to the Sonarr and Radarr widgets, where one can see the current queue.
![image](https://github.com/benphelps/homepage/assets/43815618/51d09714-cdcb-4ce3-9297-a4bdfc2c3e54)
![image](https://github.com/benphelps/homepage/assets/43815618/9ba7550e-a5a8-4a3e-ac06-d1f6b94606b0)
![image](https://github.com/benphelps/homepage/assets/43815618/505b0f0e-eb0c-4726-a347-ac2855080f97)

Currently this feature is toggled together with the sonarr.queue / radarr.queue field, since I wasn't sure on how you create new translations for new fields, but of course it could be changed to have it's own field.
I'm aware that this would add another row to those widgets, but I would like to have this feature, since the queue can't otherwise be seen by people who don't have full access to Sonarr and Radarr and since it's togglable I don't think it would be an issue.

The APIs of the widgets had to be expanded, to also get the required queue information and title information, but I made sure, no information, that isn't necessary, gets to the client, instead it's filtered on the server.

Closes # (no issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [X] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
