### PR TITLE
Fixes for portainer and kubernetes and error component

### DIFF
--- a/src/components/services/widget/error.jsx
+++ b/src/components/services/widget/error.jsx
@@ -9,10 +9,12 @@ function displayData(data) {
   return (data.type === 'Buffer') ? Buffer.from(data).toString() : JSON.stringify(data, 4);
 }
 
-export default function Error({ error: err }) {
+export default function Error({ error }) {
   const { t } = useTranslation();
 
-  const { error } = err?.data ?? { error: err };
+  if (error?.data?.error) {
+    error = error.data.error; // eslint-disable-line no-param-reassign
+  }
 
   return (
     <details className="px-1 pb-1">

--- a/src/widgets/kubernetes/component.jsx
+++ b/src/widgets/kubernetes/component.jsx
@@ -16,7 +16,7 @@ export default function Component({ service }) {
     `/api/kubernetes/stats/${widget.namespace}/${widget.app}?${podSelectorString}`);
 
   if (statsError || statusError) {
-    return <Container service={service} error={t("widget.api_error")} />;
+    return <Container service={service} error={statsError ?? statusError} />;
   }
 
   if (statusData && statusData.status !== "running") {

--- a/src/widgets/portainer/component.jsx
+++ b/src/widgets/portainer/component.jsx
@@ -1,12 +1,8 @@
-import { useTranslation } from "next-i18next";
-
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
-  const { t } = useTranslation();
-
   const { widget } = service;
 
   const { data: containersData, error: containersError } = useWidgetAPI(widget, "docker/containers/json", {
@@ -27,8 +23,9 @@ export default function Component({ service }) {
     );
   }
 
-  if (containersData.error) {
-    return <Container service={service} error={t("widget.api_error")} />;
+  if (containersData.error || !Array.isArray(containersData)) {
+    // containersData can be itself an error object
+    return <Container service={service} error={ containersData?.error ?? containersData } />;
   }
 
   const running = containersData.filter((c) => c.State === "running").length;

--- a/src/widgets/portainer/component.jsx
+++ b/src/widgets/portainer/component.jsx
@@ -23,8 +23,8 @@ export default function Component({ service }) {
     );
   }
 
-  if (containersData.error || !Array.isArray(containersData)) {
-    // containersData can be itself an error object
+  if (containersData.error || containersData.message) {
+    // containersData can be itself an error object e.g. if environment fails
     return <Container service={service} error={ containersData?.error ?? containersData } />;
   }
 


### PR DESCRIPTION
## Proposed change

Fixes for portainer when the environment is offline, and kubernetes widgets when it tries to pass error message.

A change in https://github.com/benphelps/homepage/pull/1437 broke the error output when services are behind the reversed proxy as proxy will return buffer data instead, so original code was working as intended.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
