### PR TITLE
Fix: potentially avoid `album` api call in lidarr widget, allow useWidgetAPI to not actually send a request

### DIFF
--- a/src/utils/proxy/use-widget-api.js
+++ b/src/utils/proxy/use-widget-api.js
@@ -7,7 +7,11 @@ export default function useWidgetAPI(widget, ...options) {
   if (options && options[1]?.refreshInterval) {
     config.refreshInterval = options[1].refreshInterval;
   }
-  const { data, error, mutate } = useSWR(formatProxyUrl(widget, ...options), config);
+  let url = formatProxyUrl(widget, ...options)
+  if (options[0] === "") {
+    url = null
+  }
+  const { data, error, mutate } = useSWR(url, config);
   // make the data error the top-level error
   return { data, error: data?.error ?? error, mutate }
 }

--- a/src/widgets/lidarr/component.jsx
+++ b/src/widgets/lidarr/component.jsx
@@ -9,7 +9,9 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  const { data: albumsData, error: albumsError } = useWidgetAPI(widget, "album");
+  // album API endpoint can get massive, so we prevent calling if not included in fields see https://github.com/benphelps/homepage/discussions/1577
+  const showAlbums = widget.fields?.includes('albums') || !widget.fields;
+  const { data: albumsData, error: albumsError } = useWidgetAPI(widget, showAlbums ? "album" : "");
   const { data: wantedData, error: wantedError } = useWidgetAPI(widget, "wanted/missing");
   const { data: queueData, error: queueError } = useWidgetAPI(widget, "queue/status");
 
@@ -18,7 +20,7 @@ export default function Component({ service }) {
     return <Container service={service} error={finalError} />;
   }
 
-  if (!albumsData || !wantedData || !queueData) {
+  if ((showAlbums && !albumsData) || !wantedData || !queueData) {
     return (
       <Container service={service}>
         <Block label="lidarr.wanted" />
@@ -32,7 +34,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="lidarr.wanted" value={t("common.number", { value: wantedData.totalRecords })} />
       <Block label="lidarr.queued" value={t("common.number", { value: queueData.totalCount })} />
-      <Block label="lidarr.albums" value={t("common.number", { value: albumsData.have })} />
+      {showAlbums && <Block label="lidarr.albums" value={t("common.number", { value: albumsData?.have })} />}
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
