### PR TITLE
Change: lidarr use artist instead of album

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -209,7 +209,7 @@
     "lidarr": {
         "wanted": "Wanted",
         "queued": "Queued",
-        "albums": "Albums"
+        "artists": "Artists"
     },
     "readarr": {
         "wanted": "Wanted",

--- a/src/widgets/lidarr/component.jsx
+++ b/src/widgets/lidarr/component.jsx
@@ -9,23 +9,21 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  // album API endpoint can get massive, so we prevent calling if not included in fields see https://github.com/benphelps/homepage/discussions/1577
-  const showAlbums = widget.fields?.includes('albums') || !widget.fields;
-  const { data: albumsData, error: albumsError } = useWidgetAPI(widget, showAlbums ? "album" : "");
+  const { data: artistsData, error: artistsError } = useWidgetAPI(widget, "artist");
   const { data: wantedData, error: wantedError } = useWidgetAPI(widget, "wanted/missing");
   const { data: queueData, error: queueError } = useWidgetAPI(widget, "queue/status");
 
-  if (albumsError || wantedError || queueError) {
-    const finalError = albumsError ?? wantedError ?? queueError;
+  if (artistsError || wantedError || queueError) {
+    const finalError = artistsError ?? wantedError ?? queueError;
     return <Container service={service} error={finalError} />;
   }
 
-  if ((showAlbums && !albumsData) || !wantedData || !queueData) {
+  if (!artistsData || !wantedData || !queueData) {
     return (
       <Container service={service}>
         <Block label="lidarr.wanted" />
         <Block label="lidarr.queued" />
-        <Block label="lidarr.albums" />
+        <Block label="lidarr.artists" />
       </Container>
     );
   }
@@ -34,7 +32,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="lidarr.wanted" value={t("common.number", { value: wantedData.totalRecords })} />
       <Block label="lidarr.queued" value={t("common.number", { value: queueData.totalCount })} />
-      {showAlbums && <Block label="lidarr.albums" value={t("common.number", { value: albumsData?.have })} />}
+      <Block label="lidarr.artists" value={t("common.number", { value: artistsData.length })} />
     </Container>
   );
 }

--- a/src/widgets/lidarr/widget.js
+++ b/src/widgets/lidarr/widget.js
@@ -6,11 +6,8 @@ const widget = {
   proxyHandler: genericProxyHandler,
 
   mappings: {
-    album: {
-      endpoint: "album",
-      map: (data) => ({
-        have: jsonArrayFilter(data, (item) => item?.statistics?.percentOfTracks === 100).length,
-      }),
+    artist: {
+      endpoint: "artist",
     },
     "wanted/missing": {
       endpoint: "wanted/missing",


### PR DESCRIPTION
## Proposed change

See linked issue, in the end it just doesn't seem worth it to support this field which can lead to absurdly large API output.

We can get the number of albums via the artist endpoint but not necessarily detecting how many a user has... (API just returns the total number of albums for an artist and total % of tracks.

Alternatively we could use number of tracks or something else if people want.

Closes #1577

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
