### PR TITLE
Fix: Retrieve ping url from config rather than as query parameter

### DIFF
--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import List from "components/services/list";
 import ResolvedIcon from "components/resolvedicon";
 
-export default function ServicesGroup({ services, layout, fiveColumns }) {
+export default function ServicesGroup({ group, services, layout, fiveColumns }) {
   return (
     <div
       key={services.name}
@@ -21,7 +21,7 @@ export default function ServicesGroup({ services, layout, fiveColumns }) {
         }
         <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium">{services.name}</h2>
       </div>
-      <List services={services.services} layout={layout} />
+      <List group={group} services={services.services} layout={layout} />
     </div>
   );
 }

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -11,7 +11,7 @@ import Kubernetes from "widgets/kubernetes/component";
 import { SettingsContext } from "utils/contexts/settings";
 import ResolvedIcon from "components/resolvedicon";
 
-export default function Item({ service }) {
+export default function Item({ service, group }) {
   const hasLink = service.href && service.href !== "#";
   const { settings } = useContext(SettingsContext);
   const showStats = (service.showStats === false) ? false : settings.showStats;
@@ -77,7 +77,7 @@ export default function Item({ service }) {
           <div className="absolute top-0 right-0 w-1/2 flex flex-row justify-end gap-2 mr-2">
               {service.ping && (
                 <div className="flex-shrink-0 flex items-center justify-center cursor-pointer">
-                  <Ping service={service} />
+                  <Ping group={group} service={service.name} />
                   <span className="sr-only">Ping status</span>
                 </div>
               )}

--- a/src/components/services/list.jsx
+++ b/src/components/services/list.jsx
@@ -14,7 +14,7 @@ const columnMap = [
   "grid-cols-1 md:grid-cols-2 lg:grid-cols-8",
 ];
 
-export default function List({ services, layout }) {
+export default function List({ group, services, layout }) {
   return (
     <ul
       className={classNames(
@@ -23,7 +23,7 @@ export default function List({ services, layout }) {
       )}
     >
       {services.map((service) => (
-        <Item key={service.container ?? service.app ?? service.name} service={service} />
+        <Item key={service.container ?? service.app ?? service.name} service={service} group={group} />
       ))}
     </ul>
   );

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -1,9 +1,9 @@
 import { useTranslation } from "react-i18next";
 import useSWR from "swr";
 
-export default function Ping({ service }) {
+export default function Ping({ group, service }) {
   const { t } = useTranslation();
-  const { data, error } = useSWR(`/api/ping?${new URLSearchParams({ping: service.ping}).toString()}`, {
+  const { data, error } = useSWR(`/api/ping?${new URLSearchParams({ group, service }).toString()}`, {
     refreshInterval: 30000
   });
 
@@ -23,7 +23,7 @@ export default function Ping({ service }) {
     );
   }
 
-  const statusText = `${service.ping}: HTTP status ${data.status}`;
+  const statusText = `${service}: HTTP status ${data.status}`;
   
   if (data.status > 403) {
     return (

--- a/src/pages/api/ping.js
+++ b/src/pages/api/ping.js
@@ -1,12 +1,22 @@
 import { performance } from "perf_hooks";
 
+import { getServiceItem } from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { httpProxy } from "utils/proxy/http";
 
 const logger = createLogger("ping");
 
 export default async function handler(req, res) {
-    const { ping: pingURL } = req.query;
+    const { group, service } = req.query;
+    const serviceItem = await getServiceItem(group, service);
+    if (!serviceItem) {
+        logger.debug(`No service item found for group ${group} named ${service}`);
+        return res.status(400).send({
+          error: "Unable to find service, see log for details.",
+        });
+    }
+
+    const { ping: pingURL } = serviceItem;
 
     if (!pingURL) {
         logger.debug("No ping URL specified");

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -289,7 +289,7 @@ function Home({ initialSettings }) {
         {services?.length > 0 && (
           <div className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
             {services.map((group) => (
-              <ServicesGroup key={group.name} services={group} layout={initialSettings.layout?.[group.name]} fiveColumns={settings.fiveColumns} />
+              <ServicesGroup key={group.name} group={group.name} services={group} layout={initialSettings.layout?.[group.name]} fiveColumns={settings.fiveColumns} />
             ))}
           </div>
         )}

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -328,16 +328,13 @@ export function cleanServiceGroups(groups) {
   }));
 }
 
-export default async function getServiceWidget(group, service) {
+export async function getServiceItem(group, service) {
   const configuredServices = await servicesFromConfig();
 
   const serviceGroup = configuredServices.find((g) => g.name === group);
   if (serviceGroup) {
     const serviceEntry = serviceGroup.services.find((s) => s.name === service);
-    if (serviceEntry) {
-      const { widget } = serviceEntry;
-      return widget;
-    }
+    if (serviceEntry) return serviceEntry;
   }
 
   const discoveredServices = await servicesFromDocker();
@@ -345,20 +342,24 @@ export default async function getServiceWidget(group, service) {
   const dockerServiceGroup = discoveredServices.find((g) => g.name === group);
   if (dockerServiceGroup) {
     const dockerServiceEntry = dockerServiceGroup.services.find((s) => s.name === service);
-    if (dockerServiceEntry) {
-      const { widget } = dockerServiceEntry;
-      return widget;
-    }
+    if (dockerServiceEntry) return dockerServiceEntry;
   }
 
   const kubernetesServices = await servicesFromKubernetes();
   const kubernetesServiceGroup = kubernetesServices.find((g) => g.name === group);
   if (kubernetesServiceGroup) {
     const kubernetesServiceEntry = kubernetesServiceGroup.services.find((s) => s.name === service);
-    if (kubernetesServiceEntry) {
-      const { widget } = kubernetesServiceEntry;
-      return widget;
-    }
+    if (kubernetesServiceEntry) return kubernetesServiceEntry;
+  }
+
+  return false;
+}
+
+export default async function getServiceWidget(group, service) {
+  const serviceItem = await getServiceItem(group, service);
+  if (serviceItem) {
+    const { widget } = serviceItem;
+    return widget;
   }
 
   return false;


### PR DESCRIPTION
## Proposed change

Changes the ping feature to not receive the URL from query params but rather just service group / name (which is what we use to 'find' services) and pulls the URL from service item itself. Closes potential security concern as noted in linked issue. Tested with dynamic services as well, since this does touch that code (we now need to pass `group.name` all the way down)

<img width="1023" alt="Screenshot 2023-06-11 at 9 49 51 AM" src="https://github.com/benphelps/homepage/assets/4887959/01d3906c-6fe4-4487-94b2-fb7e0dbd1f95">

Closes #1599 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
