### PR TITLE
Handle missing EOF when decompressing responses

### DIFF
--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-promise-reject-errors */
 /* eslint-disable no-param-reassign */
-import { createUnzip } from "node:zlib";
+import { createUnzip, constants as zlibConstants } from "node:zlib";
 
 import { http, https } from "follow-redirects";
 
@@ -34,7 +34,11 @@ function handleRequest(requestor, url, params) {
 
       let responseContent = response;
       if (contentEncoding === 'gzip' || contentEncoding === 'deflate') {
-        responseContent = createUnzip();
+        responseContent = createUnzip({
+          flush: zlibConstants.Z_SYNC_FLUSH,
+          finishFlush: zlibConstants.Z_SYNC_FLUSH
+        });
+
         // zlib errors
         responseContent.on("error", (e) => {
           logger.error(e);
@@ -103,6 +107,6 @@ export async function httpProxy(url, params = {}) {
       constructedUrl.pathname
     );
     logger.error(err);
-    return [500, "application/json", { error: {message: err?.message ?? "Unknown error", url, rawError: err} }, null];
+    return [500, "application/json", { error: { message: err?.message ?? "Unknown error", url, rawError: err } }, null];
   }
 }


### PR DESCRIPTION
## Proposed change

Adds zlib flushing configuration options.

Assuming that I understand the zlib documentation correctly, the EOF sequence may be omitted in some cases ([docs](https://www.bolet.org/~pornin/deflate-flush.html#:~:text=the%20sender%20can%20omit%20it)). Using the sync flush flag will handle that. I took a peek at some other http libraries ([axios](https://github.com/axios/axios/blob/v1.x/lib/adapters/http.js#L28-L31), [request](https://github.com/request/request/blob/3c0cddc7c8eb60b470e9519da85896ed7ee0081e/request.js#L1018-L1025)) and it appears that they always use those flags.

Closes #1609

## Testing Instructions
This is a little odd to test and there's some hoops to jump through.

1. Force gzip compression by adding this [before the request is made](https://github.com/benphelps/homepage/blob/main/src/utils/proxy/http.js#L30):
```js
params.headers = {
  ...params.headers ?? {},
  'accept-encoding': 'gzip, deflate',
};
```
2. Add `ping: https://kno.wled.ge/` to a config
3. On the main branch, validate that this will throw an `unexpected end of file` error
4. Check out this PR
5. Verify that the ping is successful and no error occurs

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
