### PR TITLE
Feature: support coinmarketcap slugs

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -279,6 +279,7 @@ export function cleanServiceGroups(groups) {
           container,
           currency, // coinmarketcap widget
           symbols,
+          slugs,
           defaultinterval,
           site, // unifi widget
           namespace, // kubernetes widget
@@ -308,9 +309,12 @@ export function cleanServiceGroups(groups) {
           service_group: serviceGroup.name,
         };
 
-        if (currency) cleanedService.widget.currency = currency;
-        if (symbols) cleanedService.widget.symbols = symbols;
-        if (defaultinterval) cleanedService.widget.defaultinterval = defaultinterval;
+        if (type === "coinmarketcap") {
+          if (currency) cleanedService.widget.currency = currency;
+          if (symbols) cleanedService.widget.symbols = symbols;
+          if (slugs) cleanedService.widget.slugs = slugs;
+          if (defaultinterval) cleanedService.widget.defaultinterval = defaultinterval;
+        }
 
         if (type === "docker") {
           if (server) cleanedService.widget.server = server;

--- a/src/widgets/coinmarketcap/component.jsx
+++ b/src/widgets/coinmarketcap/component.jsx
@@ -19,17 +19,26 @@ export default function Component({ service }) {
 
   const { widget } = service;
   const { symbols } = widget;
+  const { slugs } = widget;
   const currencyCode = widget.currency ?? "USD";
   const interval = widget.defaultinterval ?? dateRangeOptions[0].value;
 
   const [dateRange, setDateRange] = useState(interval);
 
-  const { data: statsData, error: statsError } = useWidgetAPI(widget, "v1/cryptocurrency/quotes/latest", {
-    symbol: `${symbols.join(",")}`,
+  const params = {
     convert: `${currencyCode}`,
-  });
+  }
 
-  if (!symbols || symbols.length === 0) {
+  // slugs >> symbols, not both
+  if (slugs?.length) {
+    params.slug = slugs.join(",");
+  } else if (symbols?.length) {
+    params.symbol = symbols.join(",");
+  }
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "v1/cryptocurrency/quotes/latest", params);
+
+  if ((!symbols && !slugs) || (symbols?.length === 0 && slugs?.length === 0)) {
     return (
       <Container service={service}>
         <Block value={t("coinmarketcap.configure")} />
@@ -50,9 +59,7 @@ export default function Component({ service }) {
   }
 
   const { data } = statsData;
-
-  // Make sure API returned valid data for the symbol
-  const validSymbols = symbols.filter(symbol => data[symbol].quote[currencyCode][`percent_change_${dateRange}`] !== null);
+  const validCryptos = Object.values(data).filter(crypto => crypto.quote[currencyCode][`percent_change_${dateRange}`] !== null)
 
   return (
     <Container service={service}>
@@ -61,28 +68,28 @@ export default function Component({ service }) {
       </div>
 
       <div className="flex flex-col w-full">
-        {validSymbols.map((symbol) => (
+        {validCryptos.map((crypto) => (
           <div
-            key={data[symbol].symbol}
+            key={crypto.id}
             className="bg-theme-200/50 dark:bg-theme-900/20 rounded m-1 flex-1 flex flex-row items-center justify-between p-1 text-xs"
           >
-            <div className="font-thin pl-2">{data[symbol].name}</div>
+            <div className="font-thin pl-2">{crypto.name}</div>
             <div className="flex flex-row text-right">
               <div className="font-bold mr-2">
                 {t("common.number", {
-                  value: data[symbol].quote[currencyCode].price,
+                  value: crypto.quote[currencyCode].price,
                   style: "currency",
                   currency: currencyCode,
                 })}
               </div>
               <div
                 className={`font-bold w-10 mr-2 ${
-                  data[symbol].quote[currencyCode][`percent_change_${dateRange}`] > 0
+                  crypto.quote[currencyCode][`percent_change_${dateRange}`] > 0
                     ? "text-emerald-300"
                     : "text-rose-300"
                 }`}
               >
-                {data[symbol].quote[currencyCode][`percent_change_${dateRange}`].toFixed(2)}%
+                {crypto.quote[currencyCode][`percent_change_${dateRange}`].toFixed(2)}%
               </div>
             </div>
           </div>

--- a/src/widgets/coinmarketcap/component.jsx
+++ b/src/widgets/coinmarketcap/component.jsx
@@ -51,6 +51,9 @@ export default function Component({ service }) {
 
   const { data } = statsData;
 
+  // Make sure API returned valid data for the symbol
+  const validSymbols = symbols.filter(symbol => data[symbol].quote[currencyCode][`percent_change_${dateRange}`] !== null);
+
   return (
     <Container service={service}>
       <div className={classNames(service.description ? "-top-10" : "-top-8", "absolute right-1")}>
@@ -58,7 +61,7 @@ export default function Component({ service }) {
       </div>
 
       <div className="flex flex-col w-full">
-        {symbols.map((symbol) => (
+        {validSymbols.map((symbol) => (
           <div
             key={data[symbol].symbol}
             className="bg-theme-200/50 dark:bg-theme-900/20 rounded m-1 flex-1 flex flex-row items-center justify-between p-1 text-xs"

--- a/src/widgets/coinmarketcap/widget.js
+++ b/src/widgets/coinmarketcap/widget.js
@@ -7,7 +7,8 @@ const widget = {
   mappings: {
     "v1/cryptocurrency/quotes/latest": {
       endpoint: "v1/cryptocurrency/quotes/latest",
-      params: ["symbol", "convert"],
+      params: ["convert"],
+      optionalParams: ["symbol", "slug"],
     },
   },
 };


### PR DESCRIPTION
## Proposed change

This allows specifying `slug` with coinmarketcap since crypto does dumb things like reuse their crypto symbols. So this supports e.g.

```yaml
          widget:
               type: coinmarketcap
               slugs: [chia-network, uniswap]
               defaultinterval: "1h"
               key: ...
```

<img width="492" alt="Screenshot 2023-07-13 at 9 30 24 PM" src="https://github.com/benphelps/homepage/assets/4887959/37ca459b-79af-445d-85e6-f04a59dcf61c">
<img width="499" alt="Screenshot 2023-07-13 at 9 30 11 PM" src="https://github.com/benphelps/homepage/assets/4887959/1eb4ffa2-db6a-463a-8548-104d1118cfaa">


Closes #1683

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] ~~If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).~~
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
