### PR TITLE
Fix: Handle tautulli response when unable to connect to Plex

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -129,7 +129,8 @@
         "playing": "Playing",
         "transcoding": "Transcoding",
         "bitrate": "Bitrate",
-        "no_active": "No Active Streams"
+        "no_active": "No Active Streams",
+        "plex_connection_error": "Check Plex Connection"
     },
     "omada": {
         "connectedAp": "Connected APs",

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -122,11 +122,11 @@ export default function Component({ service }) {
     refreshInterval: 5000,
   });
 
-  if (activityError) {
-    return <Container service={service} error={activityError} />;
+  if (activityError || (activityData && Object.keys(activityData.response.data).length === 0)) {
+    return <Container service={service} error={activityError ?? { message: t("tautulli.plex_connection_error") } } />;
   }
 
-  if (!activityData || Object.keys(activityData.response.data).length === 0) {
+  if (!activityData) {
     return (
       <div className="flex flex-col pb-1 mx-1">
         <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -126,7 +126,7 @@ export default function Component({ service }) {
     return <Container service={service} error={activityError} />;
   }
 
-  if (!activityData) {
+  if (!activityData || Object.keys(activityData.response.data).length === 0) {
     return (
       <div className="flex flex-col pb-1 mx-1">
         <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">


### PR DESCRIPTION
## Proposed change

Return an empty widget when tautulli's response data object is empty. This is a fix for when tautulli can't reach plex. The response looks like the following when it can't reach plex, which causes the `sort` option to error out.

```json
{
    "response": {
        "result": "success",
        "message": null,
        "data": {}
    }
}
```

Closes #713 

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
