### PR TITLE
Extra Jellyseer labels

### DIFF
--- a/src/widgets/jellyseerr/component.jsx
+++ b/src/widgets/jellyseerr/component.jsx
@@ -15,8 +15,8 @@ export default function Component({ service }) {
     return (
       <Container service={service}>
         <Block label="jellyseerr.total" />
-        <Block label="jellyseerr.movie" />
-        <Block label="jellyseerr.tv" />
+        <Block label="jellyseerr.movies" />
+        <Block label="jellyseerr.series" />
         <Block label="jellyseerr.pending" />
         <Block label="jellyseerr.approved" />
         <Block label="jellyseerr.declined" />
@@ -29,8 +29,8 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="jellyseerr.total" value={statsData.total} />
-      <Block label="jellyseerr.movie" value={statsData.movie} />
-      <Block label="jellyseerr.tv" value={statsData.tv} />
+      <Block label="jellyseerr.movies" value={statsData.movie} />
+      <Block label="jellyseerr.series" value={statsData.tv} />
       <Block label="jellyseerr.pending" value={statsData.pending} />
       <Block label="jellyseerr.approved" value={statsData.approved} />
       <Block label="jellyseerr.declined" value={statsData.declined} />

--- a/src/widgets/jellyseerr/component.jsx
+++ b/src/widgets/jellyseerr/component.jsx
@@ -14,8 +14,13 @@ export default function Component({ service }) {
   if (!statsData) {
     return (
       <Container service={service}>
+        <Block label="jellyseerr.total" />
+        <Block label="jellyseerr.movie" />
+        <Block label="jellyseerr.tv" />
         <Block label="jellyseerr.pending" />
         <Block label="jellyseerr.approved" />
+        <Block label="jellyseerr.declined" />
+        <Block label="jellyseerr.processing" />
         <Block label="jellyseerr.available" />
       </Container>
     );
@@ -23,8 +28,13 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
+      <Block label="jellyseerr.total" value={statsData.total} />
+      <Block label="jellyseerr.movie" value={statsData.movie} />
+      <Block label="jellyseerr.tv" value={statsData.tv} />
       <Block label="jellyseerr.pending" value={statsData.pending} />
       <Block label="jellyseerr.approved" value={statsData.approved} />
+      <Block label="jellyseerr.declined" value={statsData.declined} />
+      <Block label="jellyseerr.processing" value={statsData.processing} />
       <Block label="jellyseerr.available" value={statsData.available} />
     </Container>
   );

--- a/src/widgets/jellyseerr/widget.js
+++ b/src/widgets/jellyseerr/widget.js
@@ -8,8 +8,13 @@ const widget = {
     "request/count": {
       endpoint: "request/count",
       validate: [
+        "total",
+        "movie",
+        "tv",
         "pending",
         "approved",
+        "declined",
+        "processing",
         "available"
       ]
     },


### PR DESCRIPTION
## Proposed change

Added the following labels in the Jellyseer service: `total, movie, tv, declined, processing`
<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes # (n/a)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here:  https://github.com/benphelps/homepage-docs/pull/124
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
