### PR TITLE
Improve disclosure collapse animation

### DIFF
--- a/src/components/bookmarks/group.jsx
+++ b/src/components/bookmarks/group.jsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import classNames from "classnames";
 import { Disclosure, Transition } from '@headlessui/react';
 import { MdKeyboardArrowDown } from "react-icons/md";
@@ -6,6 +7,7 @@ import ErrorBoundary from "components/errorboundry";
 import List from "components/bookmarks/list";
 
 export default function BookmarksGroup({ group, disableCollapse }) {
+  const panel = useRef();
   return (
     <div key={group.name} className="flex-1">
     <Disclosure defaultOpen>
@@ -15,19 +17,24 @@ export default function BookmarksGroup({ group, disableCollapse }) {
           <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium">{group.name}</h2>
           <MdKeyboardArrowDown className={classNames(
             disableCollapse ? 'hidden' : '',
-            'transition-opacity opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl',
-            open ? 'rotate-180 transform' : ''
+            'transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl',
+            open ? '' : 'rotate-90'
             )} />
         </Disclosure.Button>
         <Transition
-          enter="transition duration-200 ease-out"
-          enterFrom="transform scale-75 opacity-0"
-          enterTo="transform scale-100 opacity-100"
-          leave="transition duration-75 ease-out"
-          leaveFrom="transform scale-100 opacity-100"
-          leaveTo="transform scale-75 opacity-0"
+          // Otherwise the transition group does display: none and cancels animation
+          className="!block"
+          unmount={false}
+          beforeLeave={() => {
+            panel.current.style.height = `${panel.current.scrollHeight}px`;
+            setTimeout(() => {panel.current.style.height = `0`}, 1);
+          }}
+          beforeEnter={() => {
+            panel.current.style.height = `0px`;
+            setTimeout(() => {panel.current.style.height = `${panel.current.scrollHeight}px`}, 1);
+          }}
           >
-            <Disclosure.Panel>
+            <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
               <ErrorBoundary>
                 <List bookmarks={group.bookmarks} />
               </ErrorBoundary>

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import classNames from "classnames";
 import { Disclosure, Transition } from '@headlessui/react';
 import { MdKeyboardArrowDown } from "react-icons/md";
@@ -6,6 +7,8 @@ import List from "components/services/list";
 import ResolvedIcon from "components/resolvedicon";
 
 export default function ServicesGroup({ group, services, layout, fiveColumns, disableCollapse }) {
+
+  const panel = useRef();
 
   return (
     <div
@@ -28,19 +31,24 @@ export default function ServicesGroup({ group, services, layout, fiveColumns, di
           <h2 className="flex text-theme-800 dark:text-theme-300 text-xl font-medium">{services.name}</h2>
           <MdKeyboardArrowDown className={classNames(
             disableCollapse ? 'hidden' : '',
-            'transition-opacity opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl',
-            open ? 'rotate-180 transform' : ''
+            'transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl',
+            open ? '' : 'rotate-90'
             )} />
         </Disclosure.Button>
         <Transition
-          enter="transition duration-200 ease-out"
-          enterFrom="transform scale-75 opacity-0"
-          enterTo="transform scale-100 opacity-100"
-          leave="transition duration-75 ease-out"
-          leaveFrom="transform scale-100 opacity-100"
-          leaveTo="transform scale-75 opacity-0"
+          // Otherwise the transition group does display: none and cancels animation
+          className="!block"
+          unmount={false}
+          beforeLeave={() => {
+            panel.current.style.height = `${panel.current.scrollHeight}px`;
+            setTimeout(() => {panel.current.style.height = `0`}, 1);
+          }}
+          beforeEnter={() => {
+            panel.current.style.height = `0px`;
+            setTimeout(() => {panel.current.style.height = `${panel.current.scrollHeight}px`}, 1);
+          }}
           >
-            <Disclosure.Panel>
+            <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
               <List group={group} services={services.services} layout={layout} />
             </Disclosure.Panel>
         </Transition>


### PR DESCRIPTION
## Proposed change

Improves the new collapse feature with a more modern drawer slide animation. It also allows the document to transition the layout of elements at the same time. This results in a much less jarring collapse than before where suddenly the page would shift after the animation completed. This was especially apparent for larger sections.

Please see a demo video blow

https://github.com/benphelps/homepage/assets/6865942/7e822850-7358-4560-a286-52ad27ca504f

This change was tested and works as expected for both mobile and desktop, but I don't have a mobile recording. Others can test on mobile or desktop currently on my personal `homepage` instance if they want. (URL upon request as I don't want to appear to self-promote)


<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] **Other (please explain)**

Minor improvement to a recently introduced feature.

## Checklist:

- [X] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [X] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
