### PR TITLE
Fix: error when fields specified via labels in 0.6.23

### DIFF
--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -18,7 +18,8 @@ export default function Container({ error = false, children, service }) {
   const childrenArray = Array.isArray(children) ? children : [children];
 
   let visibleChildren = childrenArray;
-  const fields = service?.widget?.fields;
+  let fields = service?.widget?.fields;
+  if (typeof service.widget.fields === 'string') fields = JSON.parse(service.widget.fields);
   const type = service?.widget?.type;
   if (fields && type) {
     // if the field contains a "." then it most likely contains a common loc value


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #1702

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
