### PR TITLE
Add snapshot host and path to Kopia widget

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -291,6 +291,8 @@ export function cleanServiceGroups(groups) {
           volume, // diskstation widget,
           enableQueue, // sonarr/radarr
           node, // Proxmox
+          snapshotHost, // kopia
+          snapshotPath,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -344,6 +346,10 @@ export function cleanServiceGroups(groups) {
         }
         if (["diskstation", "qnap"].includes(type)) {
           if (volume) cleanedService.widget.volume = volume;
+        }
+        if (type === "kopia") {
+          if (snapshotHost) cleanedService.widget.snapshotHost = snapshotHost;
+          if (snapshotPath) cleanedService.widget.snapshotPath = snapshotPath;
         }
       }
 

--- a/src/widgets/kopia/component.jsx
+++ b/src/widgets/kopia/component.jsx
@@ -41,7 +41,12 @@ export default function Component({ service }) {
     return <Container service={service} error={statusError} />;
   }
 
-  const source = statusData?.sources[0];
+  const snapshotHost = service.widget?.snapshotHost;
+  const snapshotPath = service.widget?.snapshotPath;
+
+  const source = statusData?.sources
+    .filter(el => snapshotHost ? el.source.host === snapshotHost : true)
+    .filter(el => snapshotPath ? el.source.path === snapshotPath : true)[0];
 
   if (!statusData || !source) {
     return (


### PR DESCRIPTION
## Proposed change

This PR adds two new optional settings to the Kopia widget to solve a problem with the current widget.

### Background
A Kopia backup repository can have multiple sources from multiple hosts.

Ie, 

- `HostA` have one snapshot at path `/home/user` being backed up the repository.
- `HostB` have two snapshots at paths `/home/user` and `/appdata` being backed up to the repository.
- `my-work-laptop` is manually backed up once in a while to the same repository snapshotting path `/Users/username`.

This is 5 sources, which are the 5 sources that will be returned when making an API call to `api/v1/sources` to any of the three hosts' Kopia server as they all share the same repository. The order of the sources in the API response is the order the sources were first added to the repository. So if `my-work-laptop` was the first one to use the repository, this is the data returned to be displayed in the Widget and the data from `HostA` or `HostB` can never be displayed.

The reason is that the widget currently assumes only one source and always displays the value of `sources[0]` from the API response, which would always be the laptop in the scenario above.

### Added options

The two new optional settings added are `snapshotHost` and `snapshotPath` to let the user decide which backup snapshot job to display in the widget from the backup repository. 

If none of these two new options are defined, the widget takes the first source from the response, as it worked previously, to not break existing configs. 
But with these added, users backing up multiple sources, will now have the option to choose which backup source to display in the widget. 

Here's the widget config with the two new optional settings.

```
widget:
    type: kopia
    url: http://kopia.host.or.ip:port
    username: username
    password: password
    snapshotHost: hostname
    snapshotPath: path
```

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
