### PR TITLE
Support custom colors for icons

### DIFF
--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -34,33 +34,27 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
 
   // check mdi- or si- prefixed icons
   const prefix = icon.split("-")[0];
-  const suffix = icon.split("-")[icon.split("-").length - 1];
-  
+
   if (prefix in iconSetURLs) {
     // check whether icon ends with color code
-    if (suffix.test(`[#][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9]`)) {
+    let iconName;
+    let iconColor;
+    const suffix = icon.split("-")[icon.split("-").length - 1];
 
-      const iconColor = `${suffix}`;
-      const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${suffix}`, "");
-      const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
-      return (
-        <div
-          style={{
-            width,
-            height,
-            maxWidth: '100%',
-            maxHeight: '100%',
-            background: `${iconColor}`,
-            mask: `url(${iconSource}) no-repeat center / contain`,
-            WebkitMask: `url(${iconSource}) no-repeat center / contain`,
-          }}
-        />
-      );
-    };
-    
-    // default to theme setting if no custom icon color code is provided
-    const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
+    if (!(suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null)) {
+      // set custom color code
+      iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${suffix}`, "");
+      iconColor = `${suffix}`;
+    } else {
+      // default to theme setting if no custom icon color code is provided
+      iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
+      iconColor = settings.iconStyle === "theme" ?
+              `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
+              "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
+    }
+
     const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
+
     return (
       <div
         style={{
@@ -68,15 +62,12 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
           height,
           maxWidth: '100%',
           maxHeight: '100%',
-          background: settings.iconStyle === "theme" ?
-            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
-            "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
+          background: `${iconColor}`,
           mask: `url(${iconSource}) no-repeat center / contain`,
           WebkitMask: `url(${iconSource}) no-repeat center / contain`,
         }}
       />
     );
-
   }
  
   // fallback to dashboard-icons

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -41,7 +41,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
     let iconColor;
     const suffix = icon.split("-")[icon.split("-").length - 1];
 
-    if (!(suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null)) {
+    if (!(suffix.match(`[#][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9]`) == null)) {
       // set custom color code
       iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${suffix}`, "");
       iconColor = `${suffix}`;

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -33,30 +33,53 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   }
 
   // check mdi- or si- prefixed icons
-  const prefix = icon.split("-")[0]
+  const prefix = icon.split("-")[0];
+  const suffix = icon.split("-")[icon.split("-").length - 1];
 
+  // get icon source
   if (prefix in iconSetURLs) {
-    // get icon source
-    const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
-    const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
+    // check whether icon ends with color code
+    if (!(suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null)) {
 
-    return (
-      <div
-        style={{
-          width,
-          height,
-          maxWidth: '100%',
-          maxHeight: '100%',
-          background: settings.iconStyle === "theme" ?
-            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
-            "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
-          mask: `url(${iconSource}) no-repeat center / contain`,
-          WebkitMask: `url(${iconSource}) no-repeat center / contain`,
-        }}
-      />
-    );
+      const iconColor = `${suffix}`;
+      const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${suffix}`, "");
+      const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
+      return (
+        <div
+          style={{
+            width,
+            height,
+            maxWidth: '100%',
+            maxHeight: '100%',
+            background: `${iconColor}`,
+            mask: `url(${iconSource}) no-repeat center / contain`,
+            WebkitMask: `url(${iconSource}) no-repeat center / contain`,
+          }}
+        />
+      );
+    };
+
+    if (suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null) {
+      const iconColor = settings.iconStyle === "theme" ?
+              `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
+              "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
+      const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
+      const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
+      return (
+        <div
+          style={{
+            width,
+            height,
+            maxWidth: '100%',
+            maxHeight: '100%',
+            background: `${iconColor}`,
+            mask: `url(${iconSource}) no-repeat center / contain`,
+            WebkitMask: `url(${iconSource}) no-repeat center / contain`,
+          }}
+        />
+      );
+    }
   }
-
  
   // fallback to dashboard-icons
   if (icon.endsWith(".svg")) {

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -35,8 +35,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   // check mdi- or si- prefixed icons
   const prefix = icon.split("-")[0];
   const suffix = icon.split("-")[icon.split("-").length - 1];
-
-  // get icon source
+  
   if (prefix in iconSetURLs) {
     // check whether icon ends with color code
     if (!(suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null)) {
@@ -58,27 +57,26 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
         />
       );
     };
+    // default to theme setting if no custom icon color code is provided
+    const iconColor = settings.iconStyle === "theme" ?
+            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
+            "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
+    const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
+    const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
+    return (
+      <div
+        style={{
+          width,
+          height,
+          maxWidth: '100%',
+          maxHeight: '100%',
+          background: `${iconColor}`,
+          mask: `url(${iconSource}) no-repeat center / contain`,
+          WebkitMask: `url(${iconSource}) no-repeat center / contain`,
+        }}
+      />
+    );
 
-    if (suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null) {
-      const iconColor = settings.iconStyle === "theme" ?
-              `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
-              "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
-      const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
-      const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
-      return (
-        <div
-          style={{
-            width,
-            height,
-            maxWidth: '100%',
-            maxHeight: '100%',
-            background: `${iconColor}`,
-            mask: `url(${iconSource}) no-repeat center / contain`,
-            WebkitMask: `url(${iconSource}) no-repeat center / contain`,
-          }}
-        />
-      );
-    }
   }
  
   // fallback to dashboard-icons

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -38,7 +38,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   
   if (prefix in iconSetURLs) {
     // check whether icon ends with color code
-    if (!(suffix.match(`[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]`) == null)) {
+    if (suffix.test(`[#][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9]`)) {
 
       const iconColor = `${suffix}`;
       const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${suffix}`, "");

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -36,21 +36,17 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   const prefix = icon.split("-")[0];
 
   if (prefix in iconSetURLs) {
-    // check whether icon ends with color code
-    let iconName;
-    let iconColor;
-    const suffix = icon.split("-")[icon.split("-").length - 1];
+    // default to theme setting
+    let iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
+    let iconColor = settings.iconStyle === "theme" ?
+      `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
+      "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
 
-    if (!(suffix.match(`[#][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9]`) == null)) {
-      // set custom color code
-      iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${suffix}`, "");
-      iconColor = `${suffix}`;
-    } else {
-      // default to theme setting if no custom icon color code is provided
-      iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
-      iconColor = settings.iconStyle === "theme" ?
-              `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
-              "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
+    // use custom hex color if provided
+    const colorMatches = icon.match(/[#][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]$/i)
+    if (colorMatches?.length) {
+      iconName = icon.replace(`${prefix}-`, "").replace(".svg", "").replace(`-${colorMatches[0]}`, "");
+      iconColor = `${colorMatches[0]}`;
     }
 
     const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -57,10 +57,8 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
         />
       );
     };
+    
     // default to theme setting if no custom icon color code is provided
-    const iconColor = settings.iconStyle === "theme" ?
-            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
-            "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))";
     const iconName = icon.replace(`${prefix}-`, "").replace(".svg", "");
     const iconSource = `${iconSetURLs[prefix]}${iconName}.svg`;
     return (
@@ -70,7 +68,9 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
           height,
           maxWidth: '100%',
           maxHeight: '100%',
-          background: `${iconColor}`,
+          background: settings.iconStyle === "theme" ?
+            `rgb(var(--color-${ theme === "dark" ? 300 : 900 }) / var(--tw-text-opacity, 1))` :
+            "linear-gradient(180deg, rgb(var(--color-logo-start)), rgb(var(--color-logo-stop)))",
           mask: `url(${iconSource}) no-repeat center / contain`,
           WebkitMask: `url(${iconSource}) no-repeat center / contain`,
         }}


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Enables appending a color code (e.g. "#123456") to all mdi and si icons, in order to change their color to a per-icon custom one.
If no color code is appended, defaults to current behaviour (depending on theme setting).

Example: mdi-folder-#123456

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
