### PR TITLE
Ensure spacing with custom logo

### DIFF
--- a/src/components/widgets/logo/logo.jsx
+++ b/src/components/widgets/logo/logo.jsx
@@ -8,7 +8,9 @@ export default function Logo({ options }) {
     <Container options={options}>
       <Raw>
         {options.icon ?
-        <ResolvedIcon icon={options.icon} width={48} height={48} /> :
+        <div className="mr-3">
+          <ResolvedIcon icon={options.icon} width={48} height={48} />
+        </div> :
         // fallback to homepage logo
         <div className="w-12 h-12">
           <svg


### PR DESCRIPTION
## Proposed change

Was broken by https://github.com/benphelps/homepage/pull/1603 , only applies with custom logo (and a certain concoction of widgets)

Closes #1720

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
