### PR TITLE
Enable custom refresh rate for resource widget

### DIFF
--- a/src/components/widgets/resources/cpu.jsx
+++ b/src/components/widgets/resources/cpu.jsx
@@ -5,11 +5,11 @@ import { useTranslation } from "next-i18next";
 import Resource from "../widget/resource";
 import Error from "../widget/error";
 
-export default function Cpu({ expanded }) {
+export default function Cpu({ expanded, refresh = 1500 }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/widgets/resources?type=cpu`, {
-    refreshInterval: 1500,
+    refreshInterval: refresh,
   });
 
   if (error || data?.error) {

--- a/src/components/widgets/resources/cputemp.jsx
+++ b/src/components/widgets/resources/cputemp.jsx
@@ -9,11 +9,11 @@ function convertToFahrenheit(t) {
   return t * 9/5 + 32
 }
 
-export default function CpuTemp({ expanded, units }) {
+export default function CpuTemp({ expanded, units, refresh = 1500 }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/widgets/resources?type=cputemp`, {
-    refreshInterval: 1500,
+    refreshInterval: refresh,
   });
 
   if (error || data?.error) {

--- a/src/components/widgets/resources/disk.jsx
+++ b/src/components/widgets/resources/disk.jsx
@@ -5,11 +5,11 @@ import { useTranslation } from "next-i18next";
 import Resource from "../widget/resource";
 import Error from "../widget/error";
 
-export default function Disk({ options, expanded }) {
+export default function Disk({ options, expanded, refresh = 1500 }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/widgets/resources?type=disk&target=${options.disk}`, {
-    refreshInterval: 1500,
+    refreshInterval: refresh,
   });
 
   if (error || data?.error) {

--- a/src/components/widgets/resources/memory.jsx
+++ b/src/components/widgets/resources/memory.jsx
@@ -5,11 +5,11 @@ import { useTranslation } from "next-i18next";
 import Resource from "../widget/resource";
 import Error from "../widget/error";
 
-export default function Memory({ expanded }) {
+export default function Memory({ expanded, refresh = 1500 }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/widgets/resources?type=memory`, {
-    refreshInterval: 1500,
+    refreshInterval: refresh,
   });
 
   if (error || data?.error) {

--- a/src/components/widgets/resources/resources.jsx
+++ b/src/components/widgets/resources/resources.jsx
@@ -9,16 +9,18 @@ import Uptime from "./uptime";
 
 export default function Resources({ options }) {
   const { expanded, units } = options;
+  let { refresh } = options;
+  refresh = Math.max(refresh, 1000);
   return <Container options={options}>
     <Raw>
       <div className="flex flex-row self-center flex-wrap justify-between">
-        {options.cpu && <Cpu expanded={expanded} />}
-        {options.memory && <Memory expanded={expanded} />}
+        {options.cpu && <Cpu expanded={expanded} refresh={refresh} />}
+        {options.memory && <Memory expanded={expanded} refresh={refresh} />}
         {Array.isArray(options.disk)
-          ? options.disk.map((disk) => <Disk key={disk} options={{ disk }} expanded={expanded} />)
-          : options.disk && <Disk options={options} expanded={expanded} />}
-        {options.cputemp && <CpuTemp expanded={expanded} units={units} />}
-        {options.uptime && <Uptime />}
+          ? options.disk.map((disk) => <Disk key={disk} options={{ disk }} expanded={expanded} refresh={refresh} />)
+          : options.disk && <Disk options={options} expanded={expanded} refresh={refresh} />}
+        {options.cputemp && <CpuTemp expanded={expanded} units={units} refresh={refresh} />}
+        {options.uptime && <Uptime refresh={refresh} />}
       </div>
       {options.label && (
         <div className="ml-6 pt-1 text-center text-theme-800 dark:text-theme-200 text-xs">{options.label}</div>

--- a/src/components/widgets/resources/uptime.jsx
+++ b/src/components/widgets/resources/uptime.jsx
@@ -5,11 +5,11 @@ import { useTranslation } from "next-i18next";
 import Resource from "../widget/resource";
 import Error from "../widget/error";
 
-export default function Uptime() {
+export default function Uptime({ refresh = 1500 }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/widgets/resources?type=uptime`, {
-    refreshInterval: 1500,
+    refreshInterval: refresh,
   });
 
   if (error || data?.error) {


### PR DESCRIPTION
## Proposed change

Adds the option to set a custom refresh rate for the resource widget. It reads the "refresh" setting in the widget options and, if it is a number, sets the refresh rate to this number. In case it is not a number, it defaults to the previous behavior (default refresh rate of 1500 ms).

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
