### PR TITLE
Fix: handle service container stopped causes crash in v0.6.24

### DIFF
--- a/src/components/services/widget/container.jsx
+++ b/src/components/services/widget/container.jsx
@@ -19,7 +19,7 @@ export default function Container({ error = false, children, service }) {
 
   let visibleChildren = childrenArray;
   let fields = service?.widget?.fields;
-  if (typeof service.widget.fields === 'string') fields = JSON.parse(service.widget.fields);
+  if (typeof fields === 'string') fields = JSON.parse(service.widget.fields);
   const type = service?.widget?.type;
   if (fields && type) {
     // if the field contains a "." then it most likely contains a common loc value


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #1757 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
