### PR TITLE
Fix: glances widget disk loading blocks remain after load

### DIFF
--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -37,7 +37,7 @@ export default function Widget({ options }) {
       <Resource icon={FaMemory} label={t("glances.wait")} percentage="0" />
       { options.cputemp && <Resource icon={FaThermometerHalf} label={t("glances.wait")} percentage="0" /> }
       { options.disk && !Array.isArray(options.disk) && <Resource key={options.disk} icon={FiHardDrive} label={t("glances.wait")} percentage="0" /> }
-      { options.disk && Array.isArray(options.disk) && options.disk.map((disk) => <Resource key={`disk_${disk.mnt_point}`} icon={FiHardDrive} label={t("glances.wait")} percentage="0" /> ) }
+      { options.disk && Array.isArray(options.disk) && options.disk.map((disk) => <Resource key={`disk_${disk}`} icon={FiHardDrive} label={t("glances.wait")} percentage="0" /> ) }
       { options.uptime && <Resource icon={FaRegClock} label={t("glances.wait")} percentage="0" /> }
       { options.label && <WidgetLabel label={options.label} /> }
     </Resources>;
@@ -108,7 +108,7 @@ export default function Widget({ options }) {
         expanded={options.expanded}
       />
       {disks.map((disk) => (
-        <Resource key={`disk_${disk.mnt_point}`}
+        <Resource key={`disk_${disk.mnt_point ?? disk.device_name}`}
           icon={FiHardDrive}
           value={t("common.bytes", { value: disk.free })}
           label={t("glances.free")}


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #1768 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
