### PR TITLE
Feature: card blur background option

### DIFF
--- a/src/components/bookmarks/item.jsx
+++ b/src/components/bookmarks/item.jsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import classNames from "classnames";
 
 import { SettingsContext } from "utils/contexts/settings";
 import ResolvedIcon from "components/resolvedicon";
@@ -16,7 +17,10 @@ export default function Item({ bookmark }) {
         className="block w-full text-left cursor-pointer transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10"
       >
         <div className="flex">
-          <div className="flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md">
+          <div className={classNames(
+            settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? '-' : ""}${settings.cardBlur}`,
+            "flex-shrink-0 flex items-center justify-center w-11 bg-theme-500/10 dark:bg-theme-900/50 text-theme-700 hover:text-theme-700 dark:text-theme-200 text-sm font-medium rounded-l-md"
+            )}>
             {bookmark.icon && 
               <div className="flex-shrink-0 w-5 h-5">
                 <ResolvedIcon icon={bookmark.icon} alt={bookmark.abbr} />
@@ -24,7 +28,10 @@ export default function Item({ bookmark }) {
             }
             {!bookmark.icon && bookmark.abbr}
           </div>
-          <div className="flex-1 flex items-center justify-between rounded-r-md ">
+          <div className={classNames(
+            settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? '-' : ""}${settings.cardBlur}`,
+            "flex-1 flex items-center justify-between rounded-r-md"
+            )}>
             <div className="flex-1 grow pl-3 py-2 text-xs">{bookmark.name}</div>
             <div className="px-2 py-2 truncate text-theme-500 dark:text-theme-300 text-xs">{hostname}</div>
           </div>

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -32,9 +32,11 @@ export default function Item({ service, group }) {
   return (
     <li key={service.name}>
       <div
-        className={`${
-          hasLink ? "cursor-pointer " : " "
-        }transition-all h-15 mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative overflow-clip`}
+        className={classNames(
+          settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? '-' : ""}${settings.cardBlur}`,
+          hasLink && "cursor-pointer",
+          'transition-all h-15 mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative overflow-clip'
+        )}
       >
         <div className="flex select-none z-0">
           {service.icon &&


### PR DESCRIPTION
## Proposed change

Adds a visual setting to give cards a backdrop-blur option
This uses a new setting in settings.yaml named `cardBlur` which works the same way as background.blur
Supported options are sm, md, etc. from tailwind

The downside is that you cannot apply multiple backdrop-effects, thus this only works when backdround blur saturation and brightness are disabled.
This is only an issue when the cardBlur option is used, and could be clearly described in the documentation

![image](https://github.com/benphelps/homepage/assets/1977084/5f3482e4-3a52-4372-839d-dd5abb1e768b)


<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->
[Documentation Pull Request](https://github.com/benphelps/homepage-docs/pull/133)

Closes # (issue)

#1644

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ - ] New service widget
- [ - ] Bug fix (non-breaking change which fixes an issue)
- [ ✔️ ] New feature (non-breaking change which adds functionality)
- [ ✔️ ] Other (please explain)

## Checklist:

- [ ✔️ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ - ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ - ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ✔️ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
