### PR TITLE
Fix glances metrics widget memory units

### DIFF
--- a/src/widgets/glances/metrics/memory.jsx
+++ b/src/widgets/glances/metrics/memory.jsx
@@ -50,6 +50,7 @@ export default function Component({ service }) {
         formatter={(value) => t("common.bytes", {
           value,
           maximumFractionDigits: 0,
+          binary: true,
         })}
       />
 
@@ -60,6 +61,7 @@ export default function Component({ service }) {
               {t("common.bytes", {
                 value: data.free,
                 maximumFractionDigits: 0,
+                binary: true,
               })} {t("resources.free")}
             </div>
           )}
@@ -69,6 +71,7 @@ export default function Component({ service }) {
               {t("common.bytes", {
                 value: data.total,
                 maximumFractionDigits: 0,
+                binary: true,
               })} {t("resources.total")}
             </div>
           )}
@@ -80,6 +83,7 @@ export default function Component({ service }) {
           {t("common.bytes", {
             value: data.used,
             maximumFractionDigits: 0,
+            binary: true,
           })} {t("resources.used")}
         </div>
       </Block>


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #1774

<img width="746" alt="Screenshot 2023-08-03 at 9 26 28 PM" src="https://github.com/benphelps/homepage/assets/4887959/c8839c84-e525-49af-9bff-830042d874b2">
<img width="165" alt="Screenshot 2023-08-03 at 9 26 36 PM" src="https://github.com/benphelps/homepage/assets/4887959/6266eda3-35ef-4986-b464-8875daadd56d">


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
