### PR TITLE
allow hiding section headers

### DIFF
--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -16,45 +16,47 @@ export default function ServicesGroup({ group, services, layout, fiveColumns, di
       className={classNames(
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/2 lg:basis-1/3 xl:basis-1/4",
         layout?.style !== "row" && fiveColumns ? "3xl:basis-1/5" : "",
-        "flex-1 p-1"
+        layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
       )}
     >
-      <Disclosure defaultOpen>
-      {({ open }) => (
-        <>
-        <Disclosure.Button disabled={disableCollapse} className="flex w-full select-none items-center group">
-          {layout?.icon &&
-            <div className="flex-shrink-0 mr-2 w-7 h-7">
-              <ResolvedIcon icon={layout.icon} />
-            </div>
+        <Disclosure defaultOpen>
+        {({ open }) => (
+          <>
+          { layout?.header !== false &&
+            <Disclosure.Button disabled={disableCollapse} className="flex w-full select-none items-center group">
+              {layout?.icon &&
+                <div className="flex-shrink-0 mr-2 w-7 h-7">
+                  <ResolvedIcon icon={layout.icon} />
+                </div>
+              }
+              <h2 className="flex text-theme-800 dark:text-theme-300 text-xl font-medium">{services.name}</h2>
+              <MdKeyboardArrowDown className={classNames(
+                disableCollapse ? 'hidden' : '',
+                'transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl',
+                open ? '' : 'rotate-90'
+                )} />
+            </Disclosure.Button>
           }
-          <h2 className="flex text-theme-800 dark:text-theme-300 text-xl font-medium">{services.name}</h2>
-          <MdKeyboardArrowDown className={classNames(
-            disableCollapse ? 'hidden' : '',
-            'transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl',
-            open ? '' : 'rotate-90'
-            )} />
-        </Disclosure.Button>
-        <Transition
-          // Otherwise the transition group does display: none and cancels animation
-          className="!block"
-          unmount={false}
-          beforeLeave={() => {
-            panel.current.style.height = `${panel.current.scrollHeight}px`;
-            setTimeout(() => {panel.current.style.height = `0`}, 1);
-          }}
-          beforeEnter={() => {
-            panel.current.style.height = `0px`;
-            setTimeout(() => {panel.current.style.height = `${panel.current.scrollHeight}px`}, 1);
-          }}
-          >
-            <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
-              <List group={group} services={services.services} layout={layout} />
-            </Disclosure.Panel>
-        </Transition>
-        </>
-      )}
-      </Disclosure>
+          <Transition
+            // Otherwise the transition group does display: none and cancels animation
+            className="!block"
+            unmount={false}
+            beforeLeave={() => {
+              panel.current.style.height = `${panel.current.scrollHeight}px`;
+              setTimeout(() => {panel.current.style.height = `0`}, 1);
+            }}
+            beforeEnter={() => {
+              panel.current.style.height = `0px`;
+              setTimeout(() => {panel.current.style.height = `${panel.current.scrollHeight}px`}, 1);
+            }}
+            >
+              <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
+                <List group={group} services={services.services} layout={layout} />
+              </Disclosure.Panel>
+          </Transition>
+          </>
+        )}
+        </Disclosure>
     </div>
   );
 }


### PR DESCRIPTION
## Proposed change

Allows for hiding section headers, as well as lowering the padding between these sections.

Before, without:
<img width="1527" alt="Screenshot 2023-08-06 at 4 40 47 AM" src="https://github.com/benphelps/homepage/assets/82196/36263e2e-3cf3-462a-821b-30c99cd2d0c5">

After, with:
<img width="1509" alt="Screenshot 2023-08-06 at 4 41 39 AM" src="https://github.com/benphelps/homepage/assets/82196/9651ebbf-09b3-4df8-be03-7a01c1b01e7c">

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/135
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
