### PR TITLE
Feature: mjpeg stream widget

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -297,6 +297,7 @@ export function cleanServiceGroups(groups) {
           repositoryId,
           metric, // glances
           stream, // mjpeg
+          fit,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -365,6 +366,7 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "mjpeg") {
           if (stream) cleanedService.widget.stream = stream;
+          if (fit) cleanedService.widget.fit = fit;
         }
       }
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -296,6 +296,7 @@ export function cleanServiceGroups(groups) {
           userEmail, // azuredevops
           repositoryId,
           metric, // glances
+          stream, // mjpeg
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -361,6 +362,9 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "glances") {
           if (metric) cleanedService.widget.metric = metric;
+        }
+        if (type === "mjpeg") {
+          if (stream) cleanedService.widget.stream = stream;
         }
       }
 

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -46,6 +46,7 @@ const components = {
   minecraft: dynamic(() => import("./minecraft/component")),
   miniflux: dynamic(() => import("./miniflux/component")),
   mikrotik: dynamic(() => import("./mikrotik/component")),
+  mjpeg: dynamic(() => import("./mjpeg/component")),
   moonraker: dynamic(() => import("./moonraker/component")),
   mylar: dynamic(() => import("./mylar/component")),
   navidrome: dynamic(() => import("./navidrome/component")),

--- a/src/widgets/mjpeg/component.jsx
+++ b/src/widgets/mjpeg/component.jsx
@@ -2,13 +2,13 @@ import Image from "next/image";
 
 export default function Component({ service }) {
   const { widget } = service;
-  const { stream } = widget;
+  const { stream, fit = "contain" } = widget;
 
   return (
     <div>
       <div className="absolute top-0 bottom-0 right-0 left-0">
         <Image layout="fill" objectFit="fill" className="blur-md" src={stream} alt="stream" />
-        <Image layout="fill" objectFit="contain" className="drop-shadow-2xl" src={stream} alt="stream" />
+        <Image layout="fill" objectFit={fit} className="drop-shadow-2xl" src={stream} alt="stream" />
       </div>
       <div className="absolute top-0 right-0 bottom-0 left-0 overflow-clip shadow-[inset_0_0_200px_#000] shadow-theme-700/10 dark:shadow-theme-900/10" />
       <div className="h-[68px] overflow-clip" />

--- a/src/widgets/mjpeg/component.jsx
+++ b/src/widgets/mjpeg/component.jsx
@@ -1,0 +1,17 @@
+import Image from "next/image";
+
+export default function Component({ service }) {
+  const { widget } = service;
+  const { stream } = widget;
+
+  return (
+    <div>
+      <div className="absolute top-0 bottom-0 right-0 left-0">
+        <Image layout="fill" objectFit="fill" className="blur-md" src={stream} alt="stream" />
+        <Image layout="fill" objectFit="contain" className="drop-shadow-2xl" src={stream} alt="stream" />
+      </div>
+      <div className="absolute top-0 right-0 bottom-0 left-0 overflow-clip shadow-[inset_0_0_200px_#000] shadow-theme-700/10 dark:shadow-theme-900/10" />
+      <div className="h-[68px] overflow-clip" />
+    </div>
+  );
+}

--- a/src/widgets/mjpeg/widget.js
+++ b/src/widgets/mjpeg/widget.js
@@ -1,0 +1,8 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: genericProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -40,6 +40,7 @@ import medusa from "./medusa/widget";
 import minecraft from "./minecraft/widget";
 import miniflux from "./miniflux/widget";
 import mikrotik from "./mikrotik/widget";
+import mjpeg from "./mjpeg/widget";
 import moonraker from "./moonraker/widget";
 import mylar from "./mylar/widget";
 import navidrome from "./navidrome/widget";
@@ -134,6 +135,7 @@ const widgets = {
   minecraft,
   miniflux,
   mikrotik,
+  mjpeg,
   moonraker,
   mylar,
   navidrome,


### PR DESCRIPTION
## Proposed change

Adds a new mjpeg stream widget.  Simply displays the stream in the same box area as the glances graphs, so it mixes with those well.

Looks like this:

![camera-preview](https://github.com/benphelps/homepage/assets/82196/ec2187ae-f44f-4995-93d7-151766497a57)

## Type of change

Adds a new `mjpeg` widget type.

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/136
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
