### PR TITLE
Forward cookies from request

### DIFF
--- a/src/pages/api/ping.js
+++ b/src/pages/api/ping.js
@@ -3,6 +3,7 @@ import { performance } from "perf_hooks";
 import { getServiceItem } from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { httpProxy } from "utils/proxy/http";
+import {importCookieHeader} from "../../utils/proxy/cookie-jar";
 
 const logger = createLogger("ping");
 
@@ -25,20 +26,24 @@ export default async function handler(req, res) {
         });
     }
 
+    if (req.headers.cookie) {
+        importCookieHeader(pingURL, req.headers.cookie)
+    }
+
     try {
       let startTime = performance.now();
       let [status] = await httpProxy(pingURL, {
         method: "HEAD"
       });
       let endTime = performance.now();
-      
+
       if (status > 403) {
         // try one more time as a GET in case HEAD is rejected for whatever reason
         startTime = performance.now();
         [status] = await httpProxy(pingURL);
         endTime = performance.now();
       }
-  
+
       return res.status(200).json({
         status,
         latency: endTime - startTime

--- a/src/pages/api/ping.js
+++ b/src/pages/api/ping.js
@@ -3,7 +3,7 @@ import { performance } from "perf_hooks";
 import { getServiceItem } from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { httpProxy } from "utils/proxy/http";
-import {importCookieHeader} from "../../utils/proxy/cookie-jar";
+import {importCookieHeader} from "utils/proxy/cookie-jar";
 
 const logger = createLogger("ping");
 

--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -52,7 +52,7 @@ export function importCookieHeader(url, cookieHeader) {
             // Otherwise we add a new cookie
             cookieJar.setCookieSync(new Cookie({
                 key, value
-            }), url.toString(), { ignoreError: false });
+            }), url.toString(), { ignoreError: true });
         }
     }
 }

--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -48,7 +48,9 @@ export function importCookieHeader(url, cookieHeader) {
         let existingCookie;
         try {
             existingCookie = cookieJar.getCookiesSync(url).find(existing => existing.key === key);
-        } catch {}
+        } catch (e) {
+            console.debug(`Failed to get cookies for ${url}: ${e}`)
+        }
 
         if (existingCookie) {
             existingCookie.value = value;

--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -37,3 +37,12 @@ export function addCookieToJar(url, headers) {
     cookieJar.setCookieSync(cookies[i], url.toString(), { ignoreError: true });
   }
 }
+
+export function importCookieHeader(url, cookieHeader) {
+    for (const cookiePair of cookieHeader.split(';')) {
+        const [key, value] = cookiePair.trim().split('=')
+        cookieJar.setCookieSync(new Cookie({
+            key, value
+        }), url.toString(), { ignoreError: true });
+    }
+}

--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -39,17 +39,20 @@ export function addCookieToJar(url, headers) {
 }
 
 export function importCookieHeader(url, cookieHeader) {
-    const cookies = cookieHeader.split(';')
+    const cookies = cookieHeader.split(';');
     for (let i = 0; i < cookies.length; i += 1) {
-        const [key, value] = cookies[i].trim().split('=')
+        const [key, value] = cookies[i].trim().split('=');
 
         // If there's an existing cookie with a matching key for this url,
-        // we want to update it
-        const existingCookie = cookieJar.getCookiesSync(url).find(existing => existing.key === key)
+        // we want to update it. Otherwise, we add a new cookie
+        let existingCookie;
+        try {
+            existingCookie = cookieJar.getCookiesSync(url).find(existing => existing.key === key);
+        } catch {}
+
         if (existingCookie) {
             existingCookie.value = value;
         } else {
-            // Otherwise we add a new cookie
             cookieJar.setCookieSync(new Cookie({
                 key, value
             }), url.toString(), { ignoreError: true });

--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -39,10 +39,20 @@ export function addCookieToJar(url, headers) {
 }
 
 export function importCookieHeader(url, cookieHeader) {
-    for (const cookiePair of cookieHeader.split(';')) {
-        const [key, value] = cookiePair.trim().split('=')
-        cookieJar.setCookieSync(new Cookie({
-            key, value
-        }), url.toString(), { ignoreError: true });
+    const cookies = cookieHeader.split(';')
+    for (let i = 0; i < cookies.length; i += 1) {
+        const [key, value] = cookies[i].trim().split('=')
+
+        // If there's an existing cookie with a matching key for this url,
+        // we want to update it
+        const existingCookie = cookieJar.getCookiesSync(url).find(existing => existing.key === key)
+        if (existingCookie) {
+            existingCookie.value = value;
+        } else {
+            // Otherwise we add a new cookie
+            cookieJar.setCookieSync(new Cookie({
+                key, value
+            }), url.toString(), { ignoreError: false });
+        }
     }
 }

--- a/src/utils/proxy/handlers/generic.js
+++ b/src/utils/proxy/handlers/generic.js
@@ -4,7 +4,7 @@ import validateWidgetData from "utils/proxy/validate-widget-data";
 import { httpProxy } from "utils/proxy/http";
 import createLogger from "utils/logger";
 import widgets from "widgets/widgets";
-import {importCookieHeader} from "../cookie-jar";
+import {importCookieHeader} from "utils/proxy/cookie-jar";
 
 const logger = createLogger("genericProxyHandler");
 

--- a/src/utils/proxy/handlers/generic.js
+++ b/src/utils/proxy/handlers/generic.js
@@ -4,6 +4,7 @@ import validateWidgetData from "utils/proxy/validate-widget-data";
 import { httpProxy } from "utils/proxy/http";
 import createLogger from "utils/logger";
 import widgets from "widgets/widgets";
+import {importCookieHeader} from "../cookie-jar";
 
 const logger = createLogger("genericProxyHandler");
 
@@ -35,14 +36,18 @@ export default async function genericProxyHandler(req, res, map) {
         params.body = req.body;
       }
 
+      if (req.headers.cookie) {
+          importCookieHeader(url, req.headers.cookie)
+      }
+
       const [status, contentType, data] = await httpProxy(url, params);
 
       let resultData = data;
-      
+
       if (resultData.error?.url) {
         resultData.error.url = sanitizeErrorURL(url);
       }
-      
+
       if (status === 200) {
         if (!validateWidgetData(widget, endpoint, resultData)) {
           return res.status(status).json({error: {message: "Invalid data", url: sanitizeErrorURL(url), data: resultData}});


### PR DESCRIPTION
## Proposed change

Take any cookies that are present on the request to endpoints such as `api/ping` and `api/services` and add them to the cookie jar. This means that services that are behind authentication such as authelia can be pinged and used in widgets.

The way this is done probably isn't overly correct - but it works for my usage. I thought I'd make an MR anyway to see if there was any interest in this feature.

Closes #1797

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
