### PR TITLE
Feature: mealie widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -701,5 +701,11 @@
         "errored": "Errors",
         "noRecent": "Out of Date",
         "totalUsed": "Used Storage"
+    },
+    "mealie": {
+	"recipes": "Recipes",
+	"users": "Users",
+	"categories": "Categories",
+	"tags": "Tags"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -32,6 +32,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         "authentik",
         "cloudflared",
         "ghostfolio",
+        "mealie",
         "tailscale",
         "truenas",
         "pterodactyl",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -42,6 +42,7 @@ const components = {
   kopia: dynamic(() => import("./kopia/component")),
   lidarr: dynamic(() => import("./lidarr/component")),
   mastodon: dynamic(() => import("./mastodon/component")),
+  mealie: dynamic(() => import("./mealie/component")),
   medusa: dynamic(() => import("./medusa/component")),
   minecraft: dynamic(() => import("./minecraft/component")),
   miniflux: dynamic(() => import("./miniflux/component")),

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -1,0 +1,33 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: mealieData, error: mealieError } = useWidgetAPI(widget);
+
+  if (mealieError || mealieData?.statusCode === 401) {
+    return <Container service={service} error={mealieError ?? mealieData} />;
+  }
+
+  if (!mealieData) {
+    return (
+      <Container service={service}>
+        <Block label="mealie.recipes" />
+        <Block label="mealie.users" />
+        <Block label="mealie.categories" />
+        <Block label="mealie.tags" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="mealie.recipes" value={mealieData.totalRecipes} />
+      <Block label="mealie.users" value={mealieData.totalUsers} />
+      <Block label="mealie.categories" value={mealieData.totalCategories} />
+      <Block label="mealie.tags" value={mealieData.totalTags} />
+    </Container>
+  );
+}

--- a/src/widgets/mealie/widget.js
+++ b/src/widgets/mealie/widget.js
@@ -1,0 +1,8 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/groups/statistics",
+  proxyHandler: credentialedProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -36,6 +36,7 @@ import komga from "./komga/widget";
 import kopia from "./kopia/widget";
 import lidarr from "./lidarr/widget";
 import mastodon from "./mastodon/widget";
+import mealie from "./mealie/widget";
 import medusa from "./medusa/widget";
 import minecraft from "./minecraft/widget";
 import miniflux from "./miniflux/widget";
@@ -131,6 +132,7 @@ const widgets = {
   kopia,
   lidarr,
   mastodon,
+  mealie,
   medusa,
   minecraft,
   miniflux,


### PR DESCRIPTION
## Proposed change

Adds a widget for [Mealie](https://mealie.io/) self-hosted recipe management app.
![Mealie widget](https://github.com/benphelps/homepage/assets/94425204/775fb153-7db5-4dfb-bf85-9840c8f6ef7a)

Mealie has a [well-documented API](https://nightly.mealie.io/api/redoc/) that exposes two endpoints that can be queried for statistics. I chose to query the group `Get Statistics` API that returns:
```json
{
  "totalRecipes": 0,
  "totalUsers": 0,
  "totalCategories": 0,
  "totalTags": 0,
  "totalTools": 0
}
```
 I omitted `totalTools` to keep with the Homepage standard of limiting widgets to four fields. The group `Get Statistics` API can be queried with a user-generated long-lived API token.

The other option would be to query the admin `Get Admin Statistics` that returns:
```json
{
  "totalRecipes": 0,
  "totalUsers": 0,
  "totalGroups": 0,
  "uncategorizedRecipes": 0,
  "untaggedRecipes": 0
}
```
This API can be queried by providing the admin username and password.

I felt that most users would prefer seeing categories and tags vs total groups and uncategorized or untagged recipes. I found that I needed to provide a url to the mealie-frontend (default port 9925) rather than the backend API.

```yaml
#services.yaml
- Mealie:
        href: http://mealie-frontend.host.or.ip:9925
        icon: mealie.png
        description: Recipes
        widget:
            type: mealie
            url: http://mealie-frontend.host.or.ip:9925
            key: apikey
```

Closes # https://github.com/benphelps/homepage/discussions/1790

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/142
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
