### PR TITLE
Capitalize first letter of openweather description

### DIFF
--- a/src/components/widgets/openweathermap/weather.jsx
+++ b/src/components/widgets/openweathermap/weather.jsx
@@ -32,13 +32,14 @@ function Widget({ options }) {
   }
 
   const unit = options.units === "metric" ? "celsius" : "fahrenheit";
+  const description = data.weather[0].description.charAt(0).toUpperCase() + data.weather[0].description.slice(1);
 
   const condition = data.weather[0].id;
   const timeOfDay = data.dt > data.sys.sunrise && data.dt < data.sys.sunset ? "day" : "night";
 
   return <Container options={options}>
     <PrimaryText>{options.label && `${options.label}, ` }{t("common.number", { value: data.main.temp, style: "unit", unit })}</PrimaryText>
-    <SecondaryText>{data.weather[0].description}</SecondaryText>
+    <SecondaryText>{description}</SecondaryText>
     <WidgetIcon icon={mapIcon(condition, timeOfDay)} size="xl" />
   </Container>;
 }


### PR DESCRIPTION
## Proposed change

To make the interface cleaner, I think adding a capital letter to the Open Weather description might be a good thing:

Before:
![2023-08-20_20-17-20_867](https://github.com/benphelps/homepage/assets/43747420/927e21cf-5298-4012-bcb4-1406a75cb8ee)

After:
![2023-08-20_20-17-32_481](https://github.com/benphelps/homepage/assets/43747420/884a3aa9-2fb9-4da7-a8ce-769e523d67aa)

Closes #1831

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
