### PR TITLE
Add widget for Atsumeru self-hosted media server

### DIFF
--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/ca/common.json
+++ b/public/locales/ca/common.json
@@ -492,6 +492,12 @@
         "uptime": "Uptime",
         "incident": "Incident"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Série",
+        "archives": "Archivy",
+        "chapters": "Kapitoly",
+        "categories": "Kategorie"
+    },
     "komga": {
         "libraries": "Knihovny",
         "series": "Série",

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -492,6 +492,12 @@
         "incident": "Vorfall",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Serie",
+        "archives": "Archiv",
+        "chapters": "Kapitel",
+        "categories": "Kategorien"
+    },
     "komga": {
         "libraries": "Bibliotheken",
         "series": "Serie",

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -509,6 +509,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -579,6 +579,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/eo/common.json
+++ b/public/locales/eo/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -492,6 +492,12 @@
         "incident": "Incidencia",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archivos",
+        "chapters": "Capítulos",
+        "categories": "Categorías"
+    },
     "komga": {
         "libraries": "Librerías",
         "series": "Series",

--- a/public/locales/eu/common.json
+++ b/public/locales/eu/common.json
@@ -570,6 +570,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Librairies",
         "series": "Séries",

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/hr/common.json
+++ b/public/locales/hr/common.json
@@ -492,6 +492,12 @@
         "incident": "Slučaj",
         "m": "min"
     },
+    "atsumeru": {
+        "series": "Serije",
+        "archives": "Archívum",
+        "chapters": "Fejezetek",
+        "categories": "Kategóriák"
+    },
     "komga": {
         "libraries": "Biblioteke",
         "series": "Serije",

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -425,6 +425,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -492,6 +492,12 @@
         "incident": "Incidente",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Serie",
+        "archives": "Archivio",
+        "chapters": "Capitoli",
+        "categories": "Categorie"
+    },
     "komga": {
         "libraries": "Librerie",
         "series": "Serie",

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "シリーズ",
+        "archives": "アーカイブス",
+        "chapters": "各章",
+        "categories": "カテゴリー"
+    },
     "komga": {
         "libraries": "ライブラリ",
         "series": "シリーズ",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -513,6 +513,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "시리즈",
+        "archives": "아카이브",
+        "chapters": "챕터",
+        "categories": "카테고리"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/lv/common.json
+++ b/public/locales/lv/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/ms/common.json
+++ b/public/locales/ms/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Serie",
+        "archives": "Archief",
+        "chapters": "Hoofdstukken",
+        "categories": "Categorieën"
+    },
     "komga": {
         "libraries": "Bibliotheken",
         "series": "Series",

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -492,6 +492,12 @@
         "incident": "Incydent",
         "m": "min"
     },
+    "atsumeru": {
+        "series": "Seria",
+        "archives": "Archiwa",
+        "chapters": "Rozdziały",
+        "categories": "Kategorie"
+    },
     "komga": {
         "libraries": "Biblioteki",
         "series": "Seriale",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -492,6 +492,12 @@
         "incident": "Incidente",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Série",
+        "archives": "Arquivos",
+        "chapters": "Capítulos",
+        "categories": "Categorias"
+    },
     "komga": {
         "libraries": "Bibliotecas",
         "series": "Séries",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -501,6 +501,12 @@
         "incident": "Incidente",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Série",
+        "archives": "Arquivos",
+        "chapters": "Capítulos",
+        "categories": "Categorias"
+    },
     "komga": {
         "libraries": "Bibliotecas",
         "series": "Séries",

--- a/public/locales/ro/common.json
+++ b/public/locales/ro/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -492,6 +492,12 @@
         "incident": "Инцидент",
         "m": "м"
     },
+    "atsumeru": {
+        "series": "Серии",
+        "archives": "Архивы",
+        "chapters": "Главы",
+        "categories": "Категории"
+    },
     "komga": {
         "libraries": "Библиотеки",
         "series": "Серии",

--- a/public/locales/sk/common.json
+++ b/public/locales/sk/common.json
@@ -524,6 +524,12 @@
         "cpu_usage": "CPU",
         "memory_usage": "Memory"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/sl/common.json
+++ b/public/locales/sl/common.json
@@ -545,6 +545,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Serija",
+        "archives": "Arhivi",
+        "chapters": "Poglavja",
+        "categories": "Kategorije"
+    },
     "komga": {
         "libraries": "Knjižnice",
         "series": "Serije",

--- a/public/locales/sr/common.json
+++ b/public/locales/sr/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/te/common.json
+++ b/public/locales/te/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/th/common.json
+++ b/public/locales/th/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Seri",
+        "archives": "Arşivler",
+        "chapters": "Bölümler",
+        "categories": "Kategoriler"
+    },
     "komga": {
         "libraries": "Kütüphane",
         "series": "Series",

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -492,6 +492,12 @@
         "incident": "Інцидент",
         "m": "хв"
     },
+    "atsumeru": {
+        "series": "Серії",
+        "archives": "Архіви",
+        "chapters": "Глави",
+        "categories": "Категорії"
+    },
     "komga": {
         "libraries": "Бібліотеки",
         "series": "Серії",

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/yue/common.json
+++ b/public/locales/yue/common.json
@@ -492,6 +492,12 @@
         "incident": "Incident",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "Series",
+        "archives": "Archives",
+        "chapters": "Chapters",
+        "categories": "Categories"
+    },
     "komga": {
         "libraries": "Libraries",
         "series": "Series",

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -492,6 +492,12 @@
         "incident": "严重事件",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "系列",
+        "archives": "档案",
+        "chapters": "章节",
+        "categories": "类别"
+    },
     "komga": {
         "libraries": "书库",
         "series": "系列",

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -492,6 +492,12 @@
         "incident": "事件",
         "m": "m"
     },
+    "atsumeru": {
+        "series": "系列",
+        "archives": "档案",
+        "chapters": "章节",
+        "categories": "类别"
+    },
     "komga": {
         "libraries": "文庫",
         "series": "叢刊",

--- a/src/widgets/atsumeru/component.jsx
+++ b/src/widgets/atsumeru/component.jsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: infoData, error: infoError } = useWidgetAPI(widget, "info");
+
+  if (infoError) {
+    return <Container service={service} error={infoError} />;
+  }
+
+  if (!infoData) {
+    return (
+      <Container service={service}>
+        <Block label="atsumeru.series" />
+        <Block label="atsumeru.archives" />
+        <Block label="atsumeru.chapters" />
+        <Block label="atsumeru.categories" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="atsumeru.series" value={t("common.number", { value: infoData.stats.total_series })} />
+      <Block label="atsumeru.archives" value={t("common.number", { value: infoData.stats.total_archives })} />
+      <Block label="atsumeru.chapters" value={t("common.number", { value: infoData.stats.total_chapters })} />
+      <Block label="atsumeru.categories" value={t("common.number", { value: infoData.stats.total_categories })} />
+    </Container>
+  );
+}

--- a/src/widgets/atsumeru/widget.js
+++ b/src/widgets/atsumeru/widget.js
@@ -1,0 +1,15 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+import { jsonArrayFilter, asJson } from "utils/proxy/api-helpers";
+
+const widget = {
+  api: "{url}/api/server/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    info: {
+      endpoint: "info"
+    }
+  },
+};
+
+export default widget;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 
 const components = {
   adguard: dynamic(() => import("./adguard/component")),
+  atsumeru: dynamic(() => import("./atsumeru/component")),
   audiobookshelf: dynamic(() => import("./audiobookshelf/component")),
   authentik: dynamic(() => import("./authentik/component")),
   autobrr: dynamic(() => import("./autobrr/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -1,4 +1,5 @@
 import adguard from "./adguard/widget";
+import atsumeru from "./atsumeru/widget";
 import audiobookshelf from "./audiobookshelf/widget";
 import authentik from "./authentik/widget";
 import autobrr from "./autobrr/widget";
@@ -95,6 +96,7 @@ import urbackup from "./urbackup/widget";
 
 const widgets = {
   adguard,
+  atsumeru,
   audiobookshelf,
   authentik,
   autobrr,


### PR DESCRIPTION
## Proposed change

Add widget for [Atsumeru](https://atsumeru.xyz) self-hosted mangas/comics/light novels media server 

![image](https://github.com/benphelps/homepage/assets/119543708/f675dd79-734e-4bec-85da-3b056c69ef37)

Example:
```
# services.yaml

- Atsumeru:
    - Atsumeru:
        widget:
          type: atsumeru
          url: http://localhost:31337
          username: admin
          password: admin
```

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/144
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
