### PR TITLE
Fix: apply cardBlur to header boxed / boxedWidgets

### DIFF
--- a/src/components/widgets/widget/container.jsx
+++ b/src/components/widgets/widget/container.jsx
@@ -7,6 +7,10 @@ import Raw from "./raw";
 
 export function getAllClasses(options, additionalClassNames = '') {
   if (options?.style?.header === "boxedWidgets") {
+    if (options?.style?.cardBlur !== undefined) {
+      additionalClassNames = additionalClassNames.concat(additionalClassNames, ` backdrop-blur${options.style.cardBlur.length ? '-' : ""}${options.style.cardBlur}`)
+    }
+
     return classNames(
       "flex flex-col justify-center first:ml-0 ml-2 mr-2",
       "mt-2 m:mb-0 rounded-md shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 dark:bg-white/5 p-2 pl-3 pr-3",

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -257,8 +257,9 @@ function Home({ initialSettings }) {
       <div className="relative container m-auto flex flex-col justify-start z-10 h-full">
         <div
           className={classNames(
-            "flex flex-row flex-wrap  justify-between",
-            headerStyles[headerStyle]
+            "flex flex-row flex-wrap justify-between",
+            headerStyles[headerStyle],
+            initialSettings.cardBlur !== undefined && headerStyle === "boxed" && `backdrop-blur${initialSettings.cardBlur.length ? '-' : ""}${initialSettings.cardBlur}`
           )}
         >
           <QuickLaunch
@@ -274,7 +275,7 @@ function Home({ initialSettings }) {
               {widgets
                 .filter((widget) => !rightAlignedWidgets.includes(widget.type))
                 .map((widget, i) => (
-                  <Widget key={i} widget={widget} style={{ header: headerStyle, isRightAligned: false}} />
+                  <Widget key={i} widget={widget} style={{ header: headerStyle, isRightAligned: false, cardBlur: initialSettings.cardBlur }} />
                 ))}
 
               <div className={classNames(
@@ -284,7 +285,7 @@ function Home({ initialSettings }) {
                 {widgets
                   .filter((widget) => rightAlignedWidgets.includes(widget.type))
                   .map((widget, i) => (
-                    <Widget key={i} widget={widget} style={{ header: headerStyle, isRightAligned: true}} />
+                    <Widget key={i} widget={widget} style={{ header: headerStyle, isRightAligned: true, cardBlur: initialSettings.cardBlur }} />
                   ))}
               </div>
             </>


### PR DESCRIPTION
## Proposed change

<img width="1567" alt="Screenshot 2023-08-21 at 8 43 40 AM" src="https://github.com/benphelps/homepage/assets/4887959/2f7c6f37-481b-4e29-a667-4d0a196b9834">
<img width="1533" alt="Screenshot 2023-08-21 at 8 48 09 AM" src="https://github.com/benphelps/homepage/assets/4887959/13e37ce8-5e83-406f-8d8a-95da0fc6a38a">

Closes #1828 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
