### PR TITLE
Add user and restart options to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ services:
     volumes:
       - /path/to/config:/app/config # Make sure your local config directory exists
       - /var/run/docker.sock:/var/run/docker.sock:ro # (optional) For docker integrations
-    user: 1000:1000 # default user id
+    # user: 1000:1000 optional, not compatibile with direct socket see https://gethomepage.dev/en/configs/docker/#using-socket-directly
     restart: unless-stopped
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ services:
     volumes:
       - /path/to/config:/app/config # Make sure your local config directory exists
       - /var/run/docker.sock:/var/run/docker.sock:ro # (optional) For docker integrations
+    user: 1000:1000 # default user id
+    restart: unless-stopped
 ```
 
 or docker run:


### PR DESCRIPTION
Add user:group 1000:1000 to the docker compose, to match host user. Restart container unless stopped.

## Proposed change

Change the default user. When mounting files from the host, it's better to match the host user:group. Usually that is 1000:1000, which makes it a good default.

When deploying this container, the user usually want to keep the container running persistently, hence the restart unless stopped.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (please explain)

Change example docker-compose in README.

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
