### PR TITLE
Enhancement: support extra headers in widgets

### DIFF
--- a/src/pages/api/services/proxy.js
+++ b/src/pages/api/services/proxy.js
@@ -55,6 +55,10 @@ export default async function handler(req, res) {
           req.query.endpoint = `${req.query.endpoint}?${query}`;
         }
 
+        if (mapping?.headers) {
+          req.extraHeaders = mapping.headers;
+        }
+
         if (endpointProxy instanceof Function) {
           return endpointProxy(req, res, map);
         }

--- a/src/utils/proxy/handlers/generic.js
+++ b/src/utils/proxy/handlers/generic.js
@@ -20,11 +20,10 @@ export default async function genericProxyHandler(req, res, map) {
     if (widget) {
       const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
-      let headers;
+      const headers = req.extraHeaders ?? {};
+      
       if (widget.username && widget.password) {
-        headers = {
-          Authorization: `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`,
-        };
+        headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
       }
 
       const params = {


### PR DESCRIPTION
## Proposed change

Adds support for specifying `headers` to be added to proxied requests for widgets.

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
