### PR TITLE
Allow widgets to add headers or set method

### DIFF
--- a/src/utils/proxy/handlers/generic.js
+++ b/src/utils/proxy/handlers/generic.js
@@ -20,14 +20,14 @@ export default async function genericProxyHandler(req, res, map) {
     if (widget) {
       const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
-      const headers = req.extraHeaders ?? {};
+      const headers = req.extraHeaders ?? widget.headers ?? {};
       
       if (widget.username && widget.password) {
         headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
       }
 
       const params = {
-        method: req.method,
+        method: widget.method ?? req.method,
         headers,
       }
       if (req.body) {


### PR DESCRIPTION
## Proposed change

Adds the ability for service widgets to set custom headers or method. This is specifically meant for the new `customapi` widget, but I left it generic affecting all widgets, feel free to change this. I think this is important to have at least for `customapi` in order to handle cases like non-basic authorization or custom key header authorizations for APIs.

Addresses comment https://github.com/benphelps/homepage/pull/1858#issuecomment-1694243842

![image](https://github.com/benphelps/homepage/assets/6865942/d59b527f-aa0b-47db-9192-5689e4e78102)

```yml
    - Syncthing:
        icon: mdi-sync
        widget:
          type: customapi
          url: http://syncthing:8384/rest/svc/report
          headers:
            X-API-Key: key-redacted
          mappings:
            - field: totMiB
              label: Stored (MB)
              format: number
            - field: numFolders
              label: Folders
              format: number
            - field: totFiles
              label: Files
              format: number
            - field: numDevices
              label: Devices
              format: number
```

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
