### PR TITLE
Making both Containo and Io work regardless if they are both present or not

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -161,7 +161,7 @@ export async function servicesFromKubernetes() {
     const traefikIngressListContaino = await crd.listClusterCustomObject("traefik.containo.us", "v1alpha1", "ingressroutes")
       .then((response) => response.body)
       .catch(async (error) => {
-        if (error.statusCode != 404) {
+        if (error.statusCode !== 404) {
           logger.error("Error getting traefik ingresses from traefik.containo.us: %d %s %s", error.statusCode, error.body, error.response);
         }
 
@@ -171,7 +171,7 @@ export async function servicesFromKubernetes() {
     const traefikIngressListIo = await crd.listClusterCustomObject("traefik.io", "v1alpha1", "ingressroutes")
       .then((response) => response.body)
       .catch(async (error) => {
-        if (error.statusCode != 404) {
+        if (error.statusCode !== 404) {
           logger.error("Error getting traefik ingresses from traefik.io: %d %s %s", error.statusCode, error.body, error.response);
         }        return null;
       });

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -165,7 +165,7 @@ export async function servicesFromKubernetes() {
           logger.error("Error getting traefik ingresses from traefik.containo.us: %d %s %s", error.statusCode, error.body, error.response);
         }
 
-        return null;
+        return [];
       });
 
     const traefikIngressListIo = await crd.listClusterCustomObject("traefik.io", "v1alpha1", "ingressroutes")
@@ -173,10 +173,13 @@ export async function servicesFromKubernetes() {
       .catch(async (error) => {
         if (error.statusCode !== 404) {
           logger.error("Error getting traefik ingresses from traefik.io: %d %s %s", error.statusCode, error.body, error.response);
-        }        return null;
+        }        
+        
+        return [];
       });
     
-    const traefikIngressList = [...new Set([...(traefikIngressListContaino || []), ...(traefikIngressListIo || [])])];
+    
+    const traefikIngressList = [...traefikIngressListContaino, ...traefikIngressListIo];
 
     if (traefikIngressList && traefikIngressList.items.length > 0) {
       const traefikServices = traefikIngressList.items

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -158,21 +158,25 @@ export async function servicesFromKubernetes() {
         return null;
       });
 
-    const traefikIngressList = await crd.listClusterCustomObject("traefik.io", "v1alpha1", "ingressroutes")
+    const traefikIngressListContaino = await crd.listClusterCustomObject("traefik.containo.us", "v1alpha1", "ingressroutes")
       .then((response) => response.body)
       .catch(async (error) => {
-        logger.error("Error getting traefik ingresses from traefik.io: %d %s %s", error.statusCode, error.body, error.response);
+        if (error.statusCode != 404) {
+          logger.error("Error getting traefik ingresses from traefik.containo.us: %d %s %s", error.statusCode, error.body, error.response);
+        }
 
-        // Fallback to the old traefik CRD group
-        const fallbackIngressList = await crd.listClusterCustomObject("traefik.containo.us", "v1alpha1", "ingressroutes")
-          .then((response) => response.body)
-          .catch((fallbackError) => {
-            logger.error("Error getting traefik ingresses from traefik.containo.us: %d %s %s", fallbackError.statusCode, fallbackError.body, fallbackError.response);
-            return null;
-          });
-
-        return fallbackIngressList;
+        return null;
       });
+
+    const traefikIngressListIo = await crd.listClusterCustomObject("traefik.io", "v1alpha1", "ingressroutes")
+      .then((response) => response.body)
+      .catch(async (error) => {
+        if (error.statusCode != 404) {
+          logger.error("Error getting traefik ingresses from traefik.io: %d %s %s", error.statusCode, error.body, error.response);
+        }        return null;
+      });
+    
+    const traefikIngressList = [...new Set([...(traefikIngressListContaino || []), ...(traefikIngressListIo || [])])];
 
     if (traefikIngressList && traefikIngressList.items.length > 0) {
       const traefikServices = traefikIngressList.items


### PR DESCRIPTION

## Proposed change

Two parts here:
1. Do not pollute logs if list cluster object on traefik returns 404, they resources likely are simply not there and lack of their existence would bring host of other problems that would be far more "loud" than an error log in one pod.
2. Do not use fall back logic using try  catch, if both exist in cluster unexpected behaviour can occur.

P.S. Although I am a developer by day I rarely ever touch javascript so there is a chance i did something stupid, please double check my changes.

Closes https://github.com/benphelps/homepage/issues/1874

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
