### PR TITLE
Add UptimeRobot widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -727,5 +727,19 @@
         "stopped": "Stopped",
         "passed": "Passed",
         "failed": "Failed"
+    },
+    "uptimerobot": {
+        "status": "Status",
+        "uptime": "Uptime",
+        "lastDown": "Last Downtime",
+        "downDuration": "Downtime Duration",
+        "sitesUp": "Sites Up",
+        "sitesDown": "Sites Down",
+        "paused": "Paused",
+        "notyetchecked": "Not Yet Checked",
+        "up": "Up",
+        "seemsdown": "Seems Down",
+        "down": "Down",
+        "unknown": "Unknown"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -97,6 +97,7 @@ const components = {
   unifi: dynamic(() => import("./unifi/component")),
   unmanic: dynamic(() => import("./unmanic/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),
+  uptimerobot: dynamic(() => import("./uptimerobot/component")),
   urbackup: dynamic(() => import("./urbackup/component")),
   watchtower: dynamic(() => import("./watchtower/component")),
   whatsupdocker: dynamic(() => import("./whatsupdocker/component")),

--- a/src/widgets/uptimerobot/component.jsx
+++ b/src/widgets/uptimerobot/component.jsx
@@ -1,0 +1,99 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function secondsToDhms(seconds) {
+  const d = Math.floor(seconds / (3600*24));
+  const h = Math.floor(seconds % (3600*24) / 3600);
+  const m = Math.floor(seconds % 3600 / 60);
+  const s = Math.floor(seconds % 60);
+
+  const dDisplay = d > 0 ? d + (d === 1 ? " day, " : " days, ") : "";
+  const hDisplay = h > 0 ? h + (h === 1 ? " hr, " : " hrs, ") : "";
+  let mDisplay = m > 0 && d === 0 ? m + (m === 1 ? " min" : " mins") : "";
+  let sDisplay = "";
+
+  if (d === 0 && h === 0) {
+    mDisplay = m > 0 ? m + (m === 1 ? " min, " : " mins, ") : "";
+    sDisplay = s > 0 ? s + (s === 1 ? " sec" : " secs") : "";
+  }
+  return (dDisplay + hDisplay + mDisplay + sDisplay).replace(/,\s*$/, "");
+}
+
+export default function Component({ service }) {
+  const { widget } = service;
+  const { t } = useTranslation();
+
+  const { data: uptimerobotData, error: uptimerobotError } = useWidgetAPI(widget, "getmonitors");
+
+  if (uptimerobotError) {
+    return <Container service={service} error={uptimerobotError} />;
+  }
+
+  if (!uptimerobotData) {
+    return (
+      <Container service={service}>
+        <Block label="uptimerobot.status" />
+        <Block label="uptimerobot.uptime" />
+        <Block label="uptimerobot.lastDown" />
+        <Block label="uptimerobot.downDuration" />
+      </Container>
+    );
+  }
+
+  // multiple monitors
+  if (uptimerobotData.pagination?.total > 1) {
+    const sitesUp = uptimerobotData.monitors.filter(m => m.status === 2).length;
+
+    return (
+      <Container service={service}>
+        <Block label="uptimerobot.sitesUp" value={sitesUp} />
+        <Block label="uptimerobot.sitesDown" value={uptimerobotData.pagination.total - sitesUp} />
+      </Container>
+    );
+  }
+
+  // single monitor
+  const monitor = uptimerobotData.monitors[0];
+  let status;
+  let uptime = 0;
+  let logIndex = 0;
+
+  switch (monitor.status) {
+    case 0:
+      status = t("uptimerobot.paused");
+      break;
+    case 1:
+      status = t("uptimerobot.notyetchecked");
+      break;
+    case 2:
+      status = t("uptimerobot.up");
+      uptime = secondsToDhms(monitor.logs[0].duration);
+      logIndex = 1;
+      break;
+    case 8:
+      status = t("uptimerobot.seemsdown");
+      break;
+    case 9:
+      status = t("uptimerobot.down");
+      break;
+    default:
+      status = t("uptimerobot.unknown");
+      break;
+  }
+
+  const lastDown = new Date(monitor.logs[logIndex].datetime * 1000).toLocaleString();
+  const downDuration = secondsToDhms(monitor.logs[logIndex].duration);
+  const hideDown = logIndex === 1 && monitor.logs[logIndex].type !== 1;
+
+  return (
+    <Container service={service}>
+      <Block label="uptimerobot.status" value={status} />
+      <Block label="uptimerobot.uptime" value={uptime} />
+      {!hideDown && <Block label="uptimerobot.lastDown" value={lastDown} />}
+      {!hideDown && <Block label="uptimerobot.downDuration" value={downDuration} />}
+    </Container>
+  );
+}

--- a/src/widgets/uptimerobot/widget.js
+++ b/src/widgets/uptimerobot/widget.js
@@ -1,0 +1,20 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/v2/{endpoint}?api_key={key}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    getmonitors: {
+      method: "POST",
+      endpoint: "getMonitors",
+      body: 'format=json&logs=1',
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "cache-control": "no-cache"
+      },
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -91,6 +91,7 @@ import truenas from "./truenas/widget";
 import unifi from "./unifi/widget";
 import unmanic from "./unmanic/widget";
 import uptimekuma from "./uptimekuma/widget";
+import uptimerobot from "./uptimerobot/widget";
 import watchtower from "./watchtower/widget";
 import whatsupdocker from "./whatsupdocker/widget";
 import xteve from "./xteve/widget";
@@ -192,6 +193,7 @@ const widgets = {
   unifi_console: unifi,
   unmanic,
   uptimekuma,
+  uptimerobot,
   urbackup,
   watchtower,
   whatsupdocker,


### PR DESCRIPTION
## Proposed change

Add a service widget for UptimeRobot.com. User may choose between a summary of multiple monitors, or details of a single monitor.

Closes #1827 
See #1846

Multiple monitors:
<img width="403" alt="Screenshot 2023-08-23 at 5 13 11 PM" src="https://github.com/benphelps/homepage/assets/159040/bd1437f5-ede4-4a53-b9bd-3fedc347287a">

Single monitor, currently up, with previous down time:
![Screenshot 2023-08-28 at 5 10 17 PM](https://github.com/benphelps/homepage/assets/159040/0a1c7465-162f-4f57-99fc-03681fb22339)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/149
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
