### PR TITLE
Update GameDig dependency to 4.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "compare-versions": "^5.0.1",
         "dockerode": "^3.3.4",
         "follow-redirects": "^1.15.2",
-        "gamedig": "^4.0.6",
+        "gamedig": "^4.0.7",
         "i18next": "^21.9.2",
         "js-yaml": "^4.1.0",
         "json-rpc-2.0": "^1.4.1",
@@ -2977,14 +2977,14 @@
       }
     },
     "node_modules/gamedig": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.0.6.tgz",
-      "integrity": "sha512-h0k9n/e5vNrd9Mh2wyFUp2Vo7ABWbDkdBxKC6FNJLOZiU5d9Z29bntGeYbXtOkcRWoV6Q63wSAJ3jLWxYQkpZw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.0.7.tgz",
+      "integrity": "sha512-A8bJ23ulAEp8A4ZJAHp5cMkWu4ymf6AQdOPBAa2asHQqAnf2/bIa07ClcQeeCp+bQWYqJAcW7xvUqjruSrCX4A==",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",
         "compressjs": "^1.0.2",
         "gbxremote": "^0.2.1",
-        "got": "^12.0.3",
+        "got": "^12.1.0",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.0",
         "minimist": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "compare-versions": "^5.0.1",
     "dockerode": "^3.3.4",
     "follow-redirects": "^1.15.2",
-    "gamedig": "^4.0.6",
+    "gamedig": "^4.0.7",
     "i18next": "^21.9.2",
     "js-yaml": "^4.1.0",
     "json-rpc-2.0": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^1.15.2
     version: 1.15.2
   gamedig:
-    specifier: ^4.0.6
-    version: 4.0.6
+    specifier: ^4.0.7
+    version: 4.0.7
   i18next:
     specifier: ^21.9.2
     version: 21.10.0
@@ -1972,8 +1972,8 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
 
-  /gamedig@4.0.6:
-    resolution: {integrity: sha512-h0k9n/e5vNrd9Mh2wyFUp2Vo7ABWbDkdBxKC6FNJLOZiU5d9Z29bntGeYbXtOkcRWoV6Q63wSAJ3jLWxYQkpZw==}
+  /gamedig@4.0.7:
+    resolution: {integrity: sha512-A8bJ23ulAEp8A4ZJAHp5cMkWu4ymf6AQdOPBAa2asHQqAnf2/bIa07ClcQeeCp+bQWYqJAcW7xvUqjruSrCX4A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
## Proposed change
This PR updates the GameDig dependency to the latest as of writing, `4.0.7`, this update includes support for 14 games, a minor bugfix and updated dependencies to fix potential vulnerabilities.

Related: @sahara101 asked about Sons Of The Forest support for this project on the GameDig repository: https://github.com/gamedig/node-gamedig/issues/346

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
