### PR TITLE
Add crossorigin="use-credentials" to manifest link tag.

### DIFF
--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -9,7 +9,7 @@ export default function Document() {
           content="A highly customizable homepage (or startpage / application dashboard) with Docker and service API integrations."
         />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <link rel="manifest" href="/site.webmanifest?v=4" />
+        <link rel="manifest" href="/site.webmanifest?v=4" crossorigin="use-credentials" />
         <link rel="mask-icon" href="/safari-pinned-tab.svg?v=4" color="#1e9cd7" />
       </Head>
       <body>


### PR DESCRIPTION
## Proposed change
I'm using the Traefik proxy to connect to Homepage with Authentik as the Forward Auth service. Everything works perfectly except for fetching the manifest file because it doesn't send cookies.  

The solution is to add `crossorigin="use-credentials"` to the `link` tag. 
Documented here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link

Based on: https://github.com/home-assistant/frontend/issues/940

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
