### PR TITLE
Fix: cardBlur with boxedWidgets shrinks search widget

### DIFF
--- a/src/components/widgets/widget/container.jsx
+++ b/src/components/widgets/widget/container.jsx
@@ -9,7 +9,10 @@ export function getAllClasses(options, additionalClassNames = '') {
   if (options?.style?.header === "boxedWidgets") {
     if (options?.style?.cardBlur !== undefined) {
       // eslint-disable-next-line no-param-reassign
-      additionalClassNames = additionalClassNames.concat(additionalClassNames, ` backdrop-blur${options.style.cardBlur.length ? '-' : ""}${options.style.cardBlur}`)
+      additionalClassNames = [
+        additionalClassNames,
+        `backdrop-blur${options.style.cardBlur.length ? '-' : ""}${options.style.cardBlur}`
+      ].join(' ')
     }
 
     return classNames(


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

<img width="1556" alt="Screenshot 2023-08-31 at 10 40 28 AM" src="https://github.com/benphelps/homepage/assets/4887959/d6c86f55-57b8-4f07-983f-26dd01f0ff4c">


Closes #1894

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
