### PR TITLE
Enhancement: mixed bookmarks / services layout

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import dynamic from "next/dynamic";
 import classNames from "classnames";
 import { useTranslation } from "next-i18next";
-import { useEffect, useContext, useState } from "react";
+import { useEffect, useContext, useState, useMemo } from "react";
 import { BiError } from "react-icons/bi";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
@@ -230,6 +230,66 @@ function Home({ initialSettings }) {
     }
   })
 
+  const servicesAndBookmarksGroups = useMemo(() => {
+    const layoutGroups = settings.layout ? Object.keys(settings.layout).map(
+      (groupName) => services?.find(g => g.name === groupName) ?? bookmarks?.find(b => b.name === groupName)
+    ).filter(g => g) : [];
+
+    const serviceGroups = services?.filter(group => settings.layout?.[group.name] === undefined);
+    const bookmarkGroups = bookmarks.filter(group => settings.layout?.[group.name] === undefined);
+
+    return <>
+      {layoutGroups.length > 0 && <div key="layoutGroups" className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
+        {layoutGroups.map((group) => (
+          group.services ? 
+            (<ServicesGroup
+              key={group.name}
+              group={group.name}
+              services={group}
+              layout={settings.layout?.[group.name]}
+              fiveColumns={settings.fiveColumns}
+              disableCollapse={settings.disableCollapse}
+            />) :
+            (<BookmarksGroup
+              key={group.name}
+              bookmarks={group}
+              layout={settings.layout?.[group.name]}
+              disableCollapse={settings.disableCollapse}
+            />)
+        )
+      )}
+      </div>}
+      {serviceGroups?.length > 0 && <div key="services" className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
+        {serviceGroups.map((group) => (
+          <ServicesGroup
+            key={group.name}
+            group={group.name}
+            services={group}
+            layout={settings.layout?.[group.name]}
+            fiveColumns={settings.fiveColumns}
+            disableCollapse={settings.disableCollapse}
+          />
+        ))}
+      </div>}
+      {bookmarkGroups?.length > 0 && <div key="bookmarks" className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
+        {bookmarkGroups.map((group) => (
+          <BookmarksGroup
+            key={group.name}
+            bookmarks={group}
+            layout={settings.layout?.[group.name]}
+            disableCollapse={settings.disableCollapse}
+          />
+        ))}
+      </div>}
+      </>
+  }, [
+    services,
+    bookmarks,
+    settings.layout,
+    settings.fiveColumns,
+    settings.disableCollapse
+  ]);
+
   return (
     <>
       <Head>
@@ -289,33 +349,7 @@ function Home({ initialSettings }) {
           )}
         </div>
 
-        {services?.length > 0 && (
-          <div key="services" className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
-            {services.map((group) => (
-              <ServicesGroup
-                key={group.name}
-                group={group.name}
-                services={group}
-                layout={settings.layout?.[group.name]}
-                fiveColumns={settings.fiveColumns}
-                disableCollapse={settings.disableCollapse}
-              />
-            ))}
-          </div>
-        )}
-
-        {bookmarks?.length > 0 && (
-          <div key="bookmarks" className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
-            {bookmarks.map((group) => (
-              <BookmarksGroup
-                key={group.name}
-                bookmarks={group}
-                layout={settings.layout?.[group.name]}
-                disableCollapse={settings.disableCollapse}
-              />
-            ))}
-          </div>
-        )}
+        {servicesAndBookmarksGroups}
 
         <div className="flex flex-col mt-auto p-8 w-full">
           <div className="flex w-full justify-end">


### PR DESCRIPTION
## Proposed change

This builds on top of #1902 by allowing mixing of bookmark & service groups. A couple notes:

- Any service groups or bookmark groups that aren't included in `layout` are still built like they currently are
- If a bookmark group & service group have the same name, the service wins
- [ ] docs

e.g.
```yaml
layout:
  Glances Viz:
    style: row
    columns: 2
    icon: glances.png
  Developer Tools:
    style: row
    columns: 3
  Media:
  Home Management & Info:
    icon: home-assistant.png
  Server Tools:
    icon: https://cdn-icons-png.flaticon.com/512/252/252035.png
  Downloaders:
```

<img width="1563" alt="Screenshot 2023-09-03 at 12 03 49 AM" src="https://github.com/benphelps/homepage/assets/4887959/b3cf84d3-aee1-4ea7-a541-c4261f999120">

See #89 #804 #1235

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
