### PR TITLE
Enhancement: CustomAPI widget data formats

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -306,6 +306,10 @@
         "7days": "7 Days",
         "30days": "30 Days"
     },
+    "customapi": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
     "gotify": {
         "apps": "Applications",
         "clients": "Clients",

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -1,4 +1,4 @@
-import { useTranslation } from "next-i18next";
+import {useTranslation} from "next-i18next";
 
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
@@ -30,46 +30,50 @@ function getValue(field, data) {
 function formatValue(t, mapping, value) {
   switch (mapping?.format) {
     case 'number':
-      return t("common.number", { value: parseInt(value, 10) });
+      return t("common.number", {value: parseInt(value, 10)});
     case 'float':
-      return t("common.number", { value });
+      return t("common.number", {value});
     case 'percent':
-      return t("common.percent", { value });
+      return t("common.percent", {value});
+    case 'percentBinary':
+      return t("common.percent", {value: (100 * value / 255).toFixed()});
+    case 'state':
+      return t(`customapi.${/true/.test(value) ? "active" : "inactive"}`);
     case 'text':
     default:
       return value;
   }
 }
 
-export default function Component({ service }) {
-  const { t } = useTranslation();
+export default function Component({service}) {
+  const {t} = useTranslation();
 
-  const { widget } = service;
+  const {widget} = service;
 
-  const { mappings = [], refreshInterval = 10000 } = widget;
-  const { data: customData, error: customError } = useWidgetAPI(widget, null, {
+  const {mappings = [], refreshInterval = 10000} = widget;
+  const {data: customData, error: customError} = useWidgetAPI(widget, null, {
     refreshInterval: Math.max(1000, refreshInterval),
   });
 
   if (customError) {
-    return <Container service={service} error={customError} />;
+    return <Container service={service} error={customError}/>;
   }
 
   if (!customData) {
     return (
       <Container service={service}>
-        { mappings.slice(0,4).map(item => <Block label={item.label} key={item.field} />) }
+        {mappings.slice(0, 4).map(item => <Block label={item.label} key={item.field}/>)}
       </Container>
     );
   }
 
   return (
     <Container service={service}>
-      { mappings.slice(0,4).map(mapping => <Block
+      {mappings.slice(0, 4).map(mapping => <Block
         label={mapping.label}
         key={mapping.field}
         value={formatValue(t, mapping, getValue(mapping.field, customData))}
-      />) }
+      />)}
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change
I noticed that the customapi widget does not allow for data types boolean and 8-bit values (if you want to display them as a percentage). Therefore I added boolean format as "state" which either displays "Active" or "Inactive" and corresponding translation and percentBinary which converts 8-bit values ( ≤255) to a 0-100% range.
<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
