### PR TITLE
Fix: error in glances cpu when system data not available yet

### DIFF
--- a/src/widgets/glances/metrics/cpu.jsx
+++ b/src/widgets/glances/metrics/cpu.jsx
@@ -60,7 +60,7 @@ export default function Component({ service }) {
         />
       )}
 
-      { !chart && (
+      { !chart && systemData && !systemError && (
         <Block position="top-3 right-3">
           <div className="text-xs opacity-50">
             {systemData.linux_distro && `${systemData.linux_distro} - ` }


### PR DESCRIPTION
## Proposed change

Fixes occasional 
```
Unhandled Runtime Error
TypeError: Cannot read properties of undefined (reading 'linux_distro')
```

on startup

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
