### PR TITLE
Fix: Service Widget Pterodatyl | Total servers only representing last node

### DIFF
--- a/src/widgets/pterodactyl/component.jsx
+++ b/src/widgets/pterodactyl/component.jsx
@@ -23,7 +23,7 @@ export default function Component({ service }) {
   }
 
   const totalServers = nodesData.data.reduce((total, node) => 
-    node.attributes?.relationships?.servers?.data?.length ?? 0 + total, 0);
+    (node.attributes?.relationships?.servers?.data?.length ?? 0) + total, 0);
 
   return (
     <Container service={service}>


### PR DESCRIPTION
## Proposed change
Service Widget: Pterodactyl

Fixing a math issue which result in just representing the last node server count.

Closes #1937 

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
