### PR TITLE
Added start_url in manifest.json to fulfill requirements for installable app

### DIFF
--- a/src/pages/site.webmanifest.jsx
+++ b/src/pages/site.webmanifest.jsx
@@ -26,6 +26,7 @@ export async function getServerSideProps({ res }) {
     theme_color: themes[color][theme],
     background_color: themes[color][theme],
     display: "standalone",
+    start_url: settings.startUrl || "/",
   };
 
   res.setHeader("Content-Type", "application/manifest+json");


### PR DESCRIPTION
## Context

For browsers to provide the option to install a website as an app, the manifest must meet certain requirements. One of the requirements is the `start_url` property.

## Proposed change

Added `start_url` in `manifest.json` to fulfill requirements for installable app. Value of this property can be controlled from settings.yaml or if emitted it will fallback to `"/"`.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
