### PR TITLE
Add remap, scale, and suffx to customapi fields

### DIFF
--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -28,13 +28,13 @@ function getValue(field, data) {
 }
 
 function formatValue(t, mapping, rawValue) {
-  var value = rawValue;
+  let value = rawValue;
 
   // Remap the value.
   const remaps = mapping?.remap ?? [];
-  for (let i = 0; i < remaps.length; i++) {
-    let remap = remaps[i];
-    if (remap?.any || remap?.value == value) {
+  for (let i = 0; i < remaps.length; i += 1) {
+    const remap = remaps[i];
+    if (remap?.any || remap?.value === value) {
       value = remap.to;
       break;
     }
@@ -43,12 +43,12 @@ function formatValue(t, mapping, rawValue) {
   // Scale the value. Accepts either a number to multiply by or a string
   // like "12/345".
   const scale = mapping?.scale;
-  if (typeof scale == 'number') {
-    value = value * scale;
-  } else if (typeof scale == 'string') {
-    let parts = scale.split('/');
-    let numerator = parts[0] ? parseFloat(parts[0]) : 1;
-    let denominator = parts[1] ? parseFloat(parts[1]) : 1;
+  if (typeof scale === 'number') {
+    value *= scale;
+  } else if (typeof scale === 'string') {
+    const parts = scale.split('/');
+    const numerator = parts[0] ? parseFloat(parts[0]) : 1;
+    const denominator = parts[1] ? parseFloat(parts[1]) : 1;
     value = value * numerator / denominator;
   }
 
@@ -69,12 +69,15 @@ function formatValue(t, mapping, rawValue) {
     case 'bitrate':
       value = t("common.bitrate", { value });
       break;
+    case 'text':
+    default:
+      // nothing
   }
 
   // Apply fixed suffix.
   const suffix = mapping?.suffix;
   if (suffix) {
-    value = value + ' ' + suffix;
+    value = `${value} ${suffix}`;
   }
 
   return value;


### PR DESCRIPTION
## Proposed change

I've got an [OpenEVSE](https://openevse.com/index.html) at home that I wanted to integrate with Homepage. It exposes a `/status` endpoint that returns JSON, so I [wrote a new widget](https://github.com/benphelps/homepage/compare/main...greglook:benphelps-homepage:openevse-widget) for it... then saw that the project only wants new widgets with a certain number of upvotes. :sweat_smile: 

So instead I decided to take a different approach, using the new `customapi` widget. Currently, the options for displaying data are pretty much limited to the label applied and a couple of format options. I'd like to be able to do some transformations on the values before displaying them, as well as applying unit strings to the fields. To that end, I've added a couple of new extensions to the `customapi` mapping options:

### Remapping
In each field, `remap` can be a list of rules which can replace the raw JSON value with something else. My use-case for this is turning a numeric enum value into a friendly string name. Currently I've only implemented two such rules here:
- If `value` is present it is checked for equality against the raw value.
- If `any` is `true` then the rule matches any raw value.

If a rule matches, then the raw value gets replaced with the `to` value in the config and the remapping stops checking further rules. This system is extensible to other kinds of rules later, too - for example, you could add comparisons like less-than and greater-than, or a regex-based replacement rule that supports capturing groups. One open question is whether the `value` key should be `eq` or `equals` to be more future-proof - I'm open to feedback here.

### Scaling
Often the raw value you get from an API is not in the best units for human display. The `scale` option in this PR can be used to adjust a number by multiplying or dividing it by a constant before formatting. I'm not sure if multiplying or dividing would be a more common need, so I've implemented it so that a bare number as a scale is directly multiplied - e.g. `scale: 1000` would multiply the raw value by 1,000.

However, this gets pretty awkward if you want to do something like converting bytes into kibibytes - you'd have to write `scale: 0.0009765625`. To make that case simpler, I made the setting support a string with a divisor, so you could instead write `scale: "1/1024"`. This supports any other values for the numerator and denominator, too.

### Byte Formats
Along the way I added a couple of data-related format options, so that you can format as `bytes` or `bitrate`. This might be sufficient for the request in https://github.com/benphelps/homepage/discussions/1870

### Suffixes
Finally, to support other units which don't have a built-in formatter, I added support for a `suffix` option, which is appended to the formatted value. This makes the resulting display much easier to interpret, because you don't have to remember the units for each number or awkwardly stuff them into the field label.


## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

As an example of what this looks like, I've been testing with the following configuration:
```yaml
- My First Group:
    - OpenEVSE:
        href: http://openevse.example.com/
        ping: http://openevse.example.com/
        description: EV car charger
        widget:
          type: customapi
          url: http://openevse.example.com/status
          refreshInterval: 10000
          mappings:
            - field: vehicle
              label: Vehicle
              format: text
              remap:
                - value: 0
                  to: None
                - value: 1
                  to: Connected
                - any: true
                  to: Unknown
            - field: power
              label: Power
              format: float
              scale: 0.001
              suffix: kW
            - field: session_energy
              label: 'Energy (Session)'
              format: float
              scale: 1/1000
              suffix: kWh
            - field: total_month
              label: 'Energy (Month)'
              format: float
              suffix: kWh
```
Which renders a widget like this (currently not charging my car):
![openevse-widget](https://github.com/benphelps/homepage/assets/3128434/eb244af8-9215-49b0-aa6c-3cbfb2b36a36)


## Checklist:

**Note:** I haven't opened a docs PR yet because I'd like to get feedback on the names and structure here first. I'm happy to write the docs afterwards!

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
