### PR TITLE
Feature: tabbed layouts

### DIFF
--- a/src/components/tab.jsx
+++ b/src/components/tab.jsx
@@ -1,23 +1,22 @@
 import { useContext } from "react";
 import classNames from "classnames";
 
-import { SettingsContext } from "utils/contexts/settings";
 import { TabContext } from "utils/contexts/tab";
 
 export default function Tab({ tab }) {
-  const { settings } = useContext(SettingsContext);
   const { activeTab, setActiveTab } = useContext(TabContext);
 
   return (
     <li key={tab} role="presentation"
       className={classNames(
-        "text-theme-700 dark:text-theme-200 relative h-12 w-full rounded-md flex m-1 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20",
-        activeTab === tab ? "bg-theme-700/20 dark:bg-theme-700/20" : "bg-theme-500/20 dark:bg-theme-500/20",
-        settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? '-': "" }${settings.cardBlur}`
-      )}>
+        "text-theme-700 dark:text-theme-200 relative h-8 w-full rounded-md flex m-1",
+        )}>
       <button id={`${tab}-tab`} type="button" role="tab"
               aria-controls={`#${tab}`} aria-selected={activeTab === tab ? "true" : "false"}
-              className="h-full w-full rounded-md hover:bg-white/20 dark:hover:bg-white/20 dark:hover:text-theme-300"
+              className={classNames(
+                "h-full w-full rounded-md",
+                activeTab === tab ? "bg-theme-300/20 dark:bg-white/10" : "hover:bg-theme-100/20 dark:hover:bg-white/5",
+              )}
               onClick={() => { setActiveTab(tab); window.location.hash = `#${tab}`; }}
       >{tab}</button>
     </li>

--- a/src/components/tab.jsx
+++ b/src/components/tab.jsx
@@ -1,0 +1,25 @@
+import { useContext } from "react";
+import classNames from "classnames";
+
+import { SettingsContext } from "utils/contexts/settings";
+import { TabContext } from "utils/contexts/tab";
+
+export default function Tab({ tab }) {
+  const { settings } = useContext(SettingsContext);
+  const { activeTab, setActiveTab } = useContext(TabContext);
+
+  return (
+    <li key={tab} role="presentation"
+      className={classNames(
+        "text-theme-700 dark:text-theme-200 relative h-12 w-full rounded-md flex m-1 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20",
+        activeTab === tab ? "bg-theme-700/20 dark:bg-theme-700/20" : "bg-theme-500/20 dark:bg-theme-500/20",
+        settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? '-': "" }${settings.cardBlur}`
+      )}>
+      <button id={`${tab}-tab`} type="button" role="tab"
+              aria-controls={`#${tab}`} aria-selected={activeTab === tab ? "true" : "false"}
+              className="h-full w-full rounded-md hover:bg-white/20 dark:hover:bg-white/20 dark:hover:text-theme-300"
+              onClick={() => { setActiveTab(tab); window.location.hash = `#${tab}`; }}
+      >{tab}</button>
+    </li>
+  );
+}

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -11,6 +11,7 @@ import nextI18nextConfig from "../../next-i18next.config";
 import { ColorProvider } from "utils/contexts/color";
 import { ThemeProvider } from "utils/contexts/theme";
 import { SettingsProvider } from "utils/contexts/settings";
+import { TabProvider } from "utils/contexts/tab";
 
 function MyApp({ Component, pageProps }) {
   return (
@@ -26,7 +27,9 @@ function MyApp({ Component, pageProps }) {
       <ColorProvider>
         <ThemeProvider>
           <SettingsProvider>
-            <Component {...pageProps} />
+            <TabProvider>
+              <Component {...pageProps} />
+            </TabProvider>
           </SettingsProvider>
         </ThemeProvider>
       </ColorProvider>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -7,7 +7,9 @@ import { useTranslation } from "next-i18next";
 import { useEffect, useContext, useState, useMemo } from "react";
 import { BiError } from "react-icons/bi";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useRouter } from "next/router";
 
+import Tab from "components/tab";
 import FileContent from "components/filecontent";
 import ServicesGroup from "components/services/group";
 import BookmarksGroup from "components/bookmarks/group";
@@ -19,6 +21,7 @@ import { getSettings } from "utils/config/config";
 import { ColorContext } from "utils/contexts/color";
 import { ThemeContext } from "utils/contexts/theme";
 import { SettingsContext } from "utils/contexts/settings";
+import { TabContext } from "utils/contexts/tab";
 import { bookmarksResponse, servicesResponse, widgetsResponse } from "utils/config/api-response";
 import ErrorBoundary from "components/errorboundry";
 import themes from "utils/styles/themes";
@@ -169,6 +172,8 @@ function Home({ initialSettings }) {
   const { theme, setTheme } = useContext(ThemeContext);
   const { color, setColor } = useContext(ColorContext);
   const { settings, setSettings } = useContext(SettingsContext);
+  const { activeTab, setActiveTab } = useContext(TabContext);
+  const { asPath } = useRouter();
 
   useEffect(() => {
     setSettings(initialSettings);
@@ -231,18 +236,52 @@ function Home({ initialSettings }) {
     }
   })
 
-  const servicesAndBookmarksGroups = useMemo(() => {
-    const layoutGroups = settings.layout ? Object.keys(settings.layout).map(
-      (groupName) => services?.find(g => g.name === groupName) ?? bookmarks?.find(b => b.name === groupName)
-    ).filter(g => g) : [];
+  const tabs = useMemo( () => {
+    if (!settings.layout) return [];
 
-    const serviceGroups = services?.filter(group => settings.layout?.[group.name] === undefined);
-    const bookmarkGroups = bookmarks.filter(group => settings.layout?.[group.name] === undefined);
+     return [
+      ...new Set(
+        Object.keys(settings.layout).map(
+          (groupName) => settings.layout[groupName]?.tab
+        ).filter(group => group)
+      )
+     ]
+  }, [settings.layout]);
+
+  if (!activeTab) {
+    const initialTab = decodeURI(asPath.substring(asPath.indexOf("#") + 1));
+    if (initialTab !== '/') {
+      setActiveTab(initialTab)
+    } else {
+      setActiveTab(tabs['0'] ?? false)
+    }
+  }
+
+  const servicesAndBookmarksGroups = useMemo(() => {
+    const tabGroupFilter = g => g && [activeTab, undefined].includes(settings.layout?.[g.name]?.tab);
+    const undefinedGroupFilter = g => settings.layout?.[g.name] === undefined;
+
+    const layoutGroups = Object.keys(settings.layout ?? {}).map(
+      (groupName) => services?.find(g => g.name === groupName) ?? bookmarks?.find(b => b.name === groupName)
+    ).filter(tabGroupFilter);
+
+    if (!settings.layout || !layoutGroups) {
+      // wait for settings to populate, otherwise all the widgets will be requested initially even if we are on a single tab
+      return <div />;
+    }
+
+    const serviceGroups = services?.filter(tabGroupFilter).filter(undefinedGroupFilter);
+    const bookmarkGroups = bookmarks.filter(tabGroupFilter).filter(undefinedGroupFilter);
 
     return <>
+      {tabs.length > 0 && <div key="tabs" id="tabs" className="p-4 sm:p-8 sm:pt-4 sm:pb-0">
+        <ul className="sm:flex" id="myTab" data-tabs-toggle="#myTabContent" role="tablist">
+          {tabs.map(tab => <Tab key={tab} tab={tab} />)}
+        </ul>
+      </div>}
       {layoutGroups.length > 0 && <div key="layoutGroups" id="layout-groups" className="flex flex-wrap p-4 sm:p-8 sm:pt-4 items-start pb-2">
         {layoutGroups.map((group) => (
-          group.services ? 
+          group.services ?
             (<ServicesGroup
               key={group.name}
               group={group.name}
@@ -284,6 +323,8 @@ function Home({ initialSettings }) {
       </div>}
       </>
   }, [
+    tabs,
+    activeTab,
     services,
     bookmarks,
     settings.layout,

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -236,17 +236,13 @@ function Home({ initialSettings }) {
     }
   })
 
-  const tabs = useMemo( () => {
-    if (!settings.layout) return [];
-
-     return [
-      ...new Set(
-        Object.keys(settings.layout).map(
-          (groupName) => settings.layout[groupName]?.tab
-        ).filter(group => group)
-      )
-     ]
-  }, [settings.layout]);
+  const tabs = useMemo( () => [
+    ...new Set(
+      Object.keys(settings.layout ?? {}).map(
+        (groupName) => settings.layout[groupName]?.tab
+      ).filter(group => group)
+    )
+  ], [settings.layout]);
 
   if (!activeTab) {
     const initialTab = decodeURI(asPath.substring(asPath.indexOf("#") + 1));

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -271,7 +271,10 @@ function Home({ initialSettings }) {
 
     return <>
       {tabs.length > 0 && <div key="tabs" id="tabs" className="p-4 sm:p-8 sm:pt-4 sm:pb-0">
-        <ul className="sm:flex" id="myTab" data-tabs-toggle="#myTabContent" role="tablist">
+        <ul className={classNames(
+          "sm:flex rounded-md bg-theme-100/20 dark:bg-white/5",
+          settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? '-': "" }${settings.cardBlur}`
+         )} id="myTab" data-tabs-toggle="#myTabContent" role="tablist" >
           {tabs.map(tab => <Tab key={tab} tab={tab} />)}
         </ul>
       </div>}
@@ -325,7 +328,8 @@ function Home({ initialSettings }) {
     bookmarks,
     settings.layout,
     settings.fiveColumns,
-    settings.disableCollapse
+    settings.disableCollapse,
+    settings.cardBlur
   ]);
 
   return (

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -286,6 +286,7 @@ export async function servicesFromKubernetes() {
 export function cleanServiceGroups(groups) {
   return groups.map((serviceGroup) => ({
     name: serviceGroup.name,
+    tabs: serviceGroup?.tabs,
     services: serviceGroup.services.map((service) => {
       const cleanedService = { ...service };
       if (cleanedService.showStats !== undefined) cleanedService.showStats = JSON.parse(cleanedService.showStats);

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -286,7 +286,6 @@ export async function servicesFromKubernetes() {
 export function cleanServiceGroups(groups) {
   return groups.map((serviceGroup) => ({
     name: serviceGroup.name,
-    tabs: serviceGroup?.tabs,
     services: serviceGroup.services.map((service) => {
       const cleanedService = { ...service };
       if (cleanedService.showStats !== undefined) cleanedService.showStats = JSON.parse(cleanedService.showStats);

--- a/src/utils/contexts/tab.jsx
+++ b/src/utils/contexts/tab.jsx
@@ -1,0 +1,15 @@
+import { createContext, useState, useMemo } from "react";
+
+export const TabContext = createContext();
+
+export function TabProvider({ initialTab, children }) {
+  const [activeTab, setActiveTab] = useState(false);
+
+  if (initialTab) {
+    setActiveTab(initialTab);
+  }
+
+  const value = useMemo(() => ({ activeTab, setActiveTab }), [activeTab]);
+
+  return <TabContext.Provider value={value}>{children}</TabContext.Provider>;
+}


### PR DESCRIPTION
## Proposed change

This pull request implements tabs when `tab:`  is defined in the layout configuration for at least single service/bookmark group (as suggested in https://github.com/benphelps/homepage/discussions/1316#discussioncomment-6165188).

Tabs will sort based on the order in the layout block. 
If there are no tabs defined, all services/bookmarks groups will be shown. 
If the group doesn't have a tab definition, it will be shown on every tab.
Every tab can be accessed directly by visiting Homepage URL with `#Group name` at the end of the URL.

I had a bit of trouble making a design of the tabs to look similar to the rest of the UI (using any colour), but I'm no designer so any suggestions or CSS changes are welcome. 


https://github.com/benphelps/homepage/assets/5442891/ffcacab6-9b49-4296-affe-54440eccc82b



<details>
<summary>Layout example</summary>

```yaml
  Developer Bookmark on First Tab:
    tab: First

  My First Group:
    tab: First
    style: row
    columns: 4

  My Second Group:
    tab: Second
    style: row
    columns: 4

  My Third Group:
    tab: Third
    style: row
    columns: 4

  My Forth Group:
    tab: Forth
    style: row
    columns: 4

  My Group on every Tab:
    style: row
    columns: 4

  Entertainment Bookmark on every Tab:
    style: row
```
</details>

Closes #1316 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
