### PR TITLE
Resolve bad setState warning in tabprovider

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -244,14 +244,16 @@ function Home({ initialSettings }) {
     )
   ], [settings.layout]);
 
-  if (!activeTab) {
-    const initialTab = decodeURI(asPath.substring(asPath.indexOf("#") + 1));
-    if (initialTab !== '/') {
-      setActiveTab(initialTab)
-    } else {
-      setActiveTab(tabs['0'] ?? false)
+  useEffect(() => {
+    if (!activeTab) {
+      const initialTab = decodeURI(asPath.substring(asPath.indexOf("#") + 1));
+      if (initialTab !== '/') {
+        setActiveTab(initialTab)
+      } else {
+        setActiveTab(tabs['0'] ?? false)
+      }
     }
-  }
+  })
 
   const servicesAndBookmarksGroups = useMemo(() => {
     const tabGroupFilter = g => g && [activeTab, undefined].includes(settings.layout?.[g.name]?.tab);


### PR DESCRIPTION
## Proposed change

<img width="1349" alt="Screenshot 2023-09-15 at 7 56 53 AM" src="https://github.com/benphelps/homepage/assets/4887959/42dd47e0-fdc4-4782-aa1e-40453c35018d">

Missed in #1981

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
