### PR TITLE
Fix layouts for initial tab with slugify

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -247,11 +247,7 @@ function Home({ initialSettings }) {
   useEffect(() => {
     if (!activeTab) {
       const initialTab = decodeURI(asPath.substring(asPath.indexOf("#") + 1));
-      if (initialTab !== '/') {
-        setActiveTab(initialTab)
-      } else {
-        setActiveTab(tabs['0'] ?? false)
-      }
+      setActiveTab(initialTab === '/' ? slugify(tabs['0']) : initialTab)
     }
   })
 


### PR DESCRIPTION
## Proposed change

Fixes issue for initial tab with slugified tab name.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
