### PR TITLE
Kubernetes Check for Custom Resource Definitions

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -219,9 +219,9 @@ export async function servicesFromKubernetes() {
         return [];
       });
 
-    const traefikIngressList = [...traefikIngressListContaino, ...traefikIngressListIo];
+    const traefikIngressList = [...traefikIngressListContaino?.items ?? [], ...traefikIngressListIo?.items ?? []];
 
-    if (traefikIngressList?.items?.length > 0) {
+    if (traefikIngressList.length > 0) {
       const traefikServices = traefikIngressList.items.filter(
         (ingress) => ingress.metadata.annotations && ingress.metadata.annotations[`${ANNOTATION_BASE}/href`]
       );

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -4,7 +4,7 @@ import path from "path";
 import yaml from "js-yaml";
 import Docker from "dockerode";
 import * as shvl from "shvl";
-import { CustomObjectsApi, NetworkingV1Api } from "@kubernetes/client-node";
+import { CustomObjectsApi, NetworkingV1Api, ApiextensionsV1Api } from "@kubernetes/client-node";
 
 import createLogger from "utils/logger";
 import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
@@ -141,6 +141,26 @@ function getUrlFromIngress(ingress) {
   return `${urlSchema}://${urlHost}${urlPath}`;
 }
 
+export async function checkCRD(kc, name) {
+  const apiExtensions = kc.makeApiClient(ApiextensionsV1Api);
+  const exist = await apiExtensions
+    .readCustomResourceDefinitionStatus(name)
+    .then(() => true)
+    .catch(async (error) => {
+      if (error.statusCode === 403) {
+        logger.error(
+          "Error checking if CRD %s exists. Make sure to add the following permission to your RBAC: %d %s %s",
+          name,
+          error.statusCode,
+          error.body.message
+        );
+      }
+      return false
+    });
+
+  return exist
+}
+
 export async function servicesFromKubernetes() {
   const ANNOTATION_BASE = "gethomepage.dev";
   const ANNOTATION_WIDGET_BASE = `${ANNOTATION_BASE}/widget.`;
@@ -164,11 +184,14 @@ export async function servicesFromKubernetes() {
         return null;
       });
 
+    const traefikContainoExists = await checkCRD(kc, "ingressroutes.traefik.containo.us");
+    const traefikExists = await checkCRD(kc, "ingressroutes.traefik.io");
+
     const traefikIngressListContaino = await crd
       .listClusterCustomObject("traefik.containo.us", "v1alpha1", "ingressroutes")
       .then((response) => response.body)
       .catch(async (error) => {
-        if (![403, 404].includes(error.statusCode)) {
+        if (traefikContainoExists) {
           logger.error(
             "Error getting traefik ingresses from traefik.containo.us: %d %s %s",
             error.statusCode,
@@ -184,7 +207,7 @@ export async function servicesFromKubernetes() {
       .listClusterCustomObject("traefik.io", "v1alpha1", "ingressroutes")
       .then((response) => response.body)
       .catch(async (error) => {
-        if (![403, 404].includes(error.statusCode)) {
+        if (traefikExists) {
           logger.error(
             "Error getting traefik ingresses from traefik.io: %d %s %s",
             error.statusCode,


### PR DESCRIPTION
## Proposed change

Within #1998 we discussed that the RBAC for the Kubernetes service account currently needs the following permission to not run into errors and spam the log. 
```
- apiGroups:
      - traefik.io
      - traefik.containo.us
    resources:
      - ingressroutes
    verbs:
      - get
      - list
```

This is needed even if you have no custom resource definitions of traefik. If you have this permission not in place the kubernetes-client in "service-helpers.js" will run into an error because you can not access the CRD. You have to add the permission to silence the alert but because you do not have the CRDs installed the next API call will fail too. Until now this was simply silenced with an statusCode != 404 if-clause. @benphelps  extended this today to exclude 403 errors which are generated if you do not have the above RBAC in place. 

With this change it is first checked if the CRDs are present. If they are not no further call is been made. If they are present they will be called. In case of an error every error will then be logged, because we do not have to exclude 404 or 403 here anymore. 

This change is some kind breaking because for this CRD check you will now need an new RBAC permission: 
```
  - apiGroups:
      - apiextensions.k8s.io
    resources:
      - customresourcedefinitions/status
    verbs:
      - get
```
If you do not have this in place a meaningful error message will be logged. 

If this change is considered to be merged I will put a MR to the unofficial helm chart to extent this RBAC permission and maybe exclude the traefik ones. 

This function can be used for more than the current traefik CRDs if there will be added more CRDs to the logic of service-helpers.js in the future. 

Happy to discuss this change!

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
