### PR TITLE
Fix: SMART result of OMV should always from monitored devices

### DIFF
--- a/src/widgets/openmediavault/methods/smart_get_list.jsx
+++ b/src/widgets/openmediavault/methods/smart_get_list.jsx
@@ -3,13 +3,13 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 
 const passedReduce = (acc, e) => {
-  if (e.overallstatus === "GOOD") {
+  if (e.monitor && e.overallstatus === "GOOD") {
     return acc + 1;
   }
   return acc;
 };
 const failedReduce = (acc, e) => {
-  if (e.overallstatus !== "GOOD") {
+  if (e.monitor && e.overallstatus !== "GOOD") {
     return acc + 1;
   }
   return acc;


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->
Current OpenMediaVault widget didn't ignore device which is not monitored. This change would filter SMART result by monitor property.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
