### PR TITLE
Fix: jdownloader remaining should be 0 after download complete

### DIFF
--- a/src/widgets/jdownloader/proxy.js
+++ b/src/widgets/jdownloader/proxy.js
@@ -176,11 +176,9 @@ export default async function jdownloaderProxyHandler(req, res) {
     let totalSpeed = 0;
     packageStatus.forEach(file => {
         totalBytes += file.bytesTotal;
-        if (file.finished !== true) {
-          totalLoaded += file.bytesLoaded;
-            if (file.speed) {
-                totalSpeed += file.speed;
-            }
+        totalLoaded += file.bytesLoaded;
+        if (file.finished !== true && file.speed) {
+            totalSpeed += file.speed;
         }
     });
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #2031

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
