### PR TITLE
Adding User-Agent header

### DIFF
--- a/src/pages/api/ping.js
+++ b/src/pages/api/ping.js
@@ -28,7 +28,8 @@ export default async function handler(req, res) {
     try {
       let startTime = performance.now();
       let [status] = await httpProxy(pingURL, {
-        method: "HEAD"
+        method: "HEAD",
+        headers: {"User-Agent":"homepage"},
       });
       let endTime = performance.now();
       


### PR DESCRIPTION
Some application return status 500 if User-Agent header is missing from HTTP request

## Proposed change

Add 'User-Agent' header to HttpProxy requests.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
