### PR TITLE
Fix: add maximumFractionDigits to Glances free fs

### DIFF
--- a/src/widgets/glances/metrics/fs.jsx
+++ b/src/widgets/glances/metrics/fs.jsx
@@ -53,7 +53,7 @@ export default function Component({ service }) {
         <div className="text-xs opacity-75">
           {t("common.bbytes", {
             value: fsData.free,
-            maximumFractionDigits: 0,
+            maximumFractionDigits: 1,
           })} {t("resources.free")}
         </div>
       </Block>


### PR DESCRIPTION
## Proposed change

Fix Glances free fs display in widget...

Before: ![imatge](https://github.com/benphelps/homepage/assets/13131391/cf6e3a97-da5a-4eb4-bf5f-c426695cd558)

After: ![imatge](https://github.com/benphelps/homepage/assets/13131391/926d333e-9b98-4e52-b197-4a26752c523b)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
