### PR TITLE
Fix: collapsing service group prevents resize / stats

### DIFF
--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -49,6 +49,7 @@ export default function ServicesGroup({ group, services, layout, fiveColumns, di
             beforeEnter={() => {
               panel.current.style.height = `0px`;
               setTimeout(() => {panel.current.style.height = `${panel.current.scrollHeight}px`}, 1);
+              setTimeout(() => {panel.current.style.height = 'auto'}, 150); // animation is 150ms
             }}
             >
               <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Closes #2052 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
