### PR TITLE
Fix: add maximumFractionDigits to Glances memory

### DIFF
--- a/src/widgets/glances/metrics/memory.jsx
+++ b/src/widgets/glances/metrics/memory.jsx
@@ -65,7 +65,7 @@ export default function Component({ service }) {
             <div className="text-xs opacity-50">
               {t("common.bytes", {
                 value: data.free,
-                maximumFractionDigits: 0,
+                maximumFractionDigits: 1,
                 binary: true,
               })} {t("resources.free")}
             </div>
@@ -75,7 +75,7 @@ export default function Component({ service }) {
             <div className="text-xs opacity-50">
               {t("common.bytes", {
                 value: data.total,
-                maximumFractionDigits: 0,
+                maximumFractionDigits: 1,
                 binary: true,
               })} {t("resources.total")}
             </div>
@@ -89,7 +89,7 @@ export default function Component({ service }) {
             <div className="text-xs opacity-50">
               {t("common.bytes", {
                 value: data.free,
-                maximumFractionDigits: 0,
+                maximumFractionDigits: 1,
                 binary: true,
               })} {t("resources.free")}
             </div>
@@ -101,7 +101,7 @@ export default function Component({ service }) {
         <div className="text-xs font-bold opacity-75">
           {t("common.bytes", {
             value: data.used,
-            maximumFractionDigits: 0,
+            maximumFractionDigits: 1,
             binary: true,
           })} {t("resources.used")}
         </div>


### PR DESCRIPTION
## Proposed change

Fix Glances memory display in widget (with and without chart)...

![imatge](https://github.com/benphelps/homepage/assets/13131391/1a58773c-ec7d-425b-a445-37f5be783845)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
