### PR TITLE
New ping-indicator styles

### DIFF
--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -29,8 +29,6 @@ export default function Item({ service, group }) {
     }
   };
 
-
-
   return (
     <li key={service.name} id={service.id} className="service" data-name={service.name || ""}>
       <div
@@ -81,7 +79,7 @@ export default function Item({ service, group }) {
           <div className="absolute top-0 right-0 flex flex-row justify-end gap-2 mr-2 z-30 service-tags">
               {service.ping && (
                 <div className="flex-shrink-0 flex items-center justify-center service-tag service-ping">
-                  <Ping group={group} service={service.name} />
+                  <Ping group={group} service={service.name} style={service.pingStyle} />
                   <span className="sr-only">Ping status</span>
                 </div>
               )}

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -79,7 +79,7 @@ export default function Item({ service, group }) {
           <div className="absolute top-0 right-0 flex flex-row justify-end gap-2 mr-2 z-30 service-tags">
               {service.ping && (
                 <div className="flex-shrink-0 flex items-center justify-center service-tag service-ping">
-                  <Ping group={group} service={service.name} style={service.pingStyle} />
+                  <Ping group={group} service={service.name} style={service.statusStyle} />
                   <span className="sr-only">Ping status</span>
                 </div>
               )}

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -7,57 +7,52 @@ export default function Ping({ group, service, style }) {
     refreshInterval: 30000
   });
 
+  let textSize = "text-[8px]";
+  let colorClass = ""
+  let backgroundClass = "bg-theme-500/10 dark:bg-theme-900/50";
+  let statusTitle = "HTTP status";
+  let statusText;
+
   if (error) {
-    return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden ping-error">
-        <div className="text-[8px] font-bold text-rose-500 uppercase">{t("ping.error")}</div>
-      </div>
-    );
-  }
-  
-  if (!data) {
-    return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden ping-ping">
-        <div className="text-[8px] font-bold text-black/20 dark:text-white/40 uppercase">{t("ping.ping")}</div>
-      </div>
-    );
-  }
-
-  let statusText = `HTTP status ${data.status}`;
-  let status;
-
-  if (data.status > 403) {
+    colorClass = "text-rose-500"
+    statusText = t("ping.error")
+    statusTitle += " error"
+  } else if (!data) {
+    colorClass = "text-black/20 dark:text-white/40"
+    statusText = t("ping.ping")
+    statusTitle += " not available"
+  } else if (data.status > 403) {
+    colorClass = "text-rose-500/80"
+    statusTitle += ` ${data.status}`
+    
     if (style === "basic") {
-      status = t("docker.offline")
+      statusText = t("docker.offline")
     } else if (style === "dot") {
-      status = "◉"
+      statusText = "◉"
+      textSize += "text-[10px]"
+      backgroundClass = ""
     } else {
-      status = data.status
+      statusText = data.status
     }
-
-    return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden ping-status-invalid" title={statusText}>
-        <div className="text-[8px] font-bold text-rose-500/80 uppercase">{status}</div>
-      </div>
-    );
-  }
-
-  // Sucessful ping
-  const ping = t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })
-
-  statusText += ` (${ping})`;
-
-  if (style === "basic") {
-    status = t("docker.running")
-  } else if (style === "dot") {
-    status = "◉"
   } else {
-    status = ping
+    const ping = t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })
+    statusTitle += ` ${data.status} (${ping})`;
+    colorClass = "text-emerald-500/80"
+
+    if (style === "basic") {
+      statusText = t("docker.running")
+    } else if (style === "dot") {
+      statusText = "◉"
+      textSize += "text-[10px]"
+      backgroundClass = ""
+    } else {
+      statusText = ping
+    }
   }
 
   return (
-    <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden ping-status-valid" title={statusText}>
-      <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{status}</div>
+    <div className={`w-auto px-1.5 py-0.5 text-center rounded-b-[3px] overflow-hidden ping-status-invalid ${backgroundClass}`} title={statusTitle}>
+      <div className={`font-bold uppercase ${textSize} ${colorClass}`}>{statusText}</div>
     </div>
   );
 }

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -24,12 +24,12 @@ export default function Ping({ group, service, style }) {
   } else if (data.status > 403) {
     colorClass = "text-rose-500/80"
     statusTitle += ` ${data.status}`
-    
+
     if (style === "basic") {
       statusText = t("docker.offline")
     } else if (style === "dot") {
       statusText = "◉"
-      textSize += "text-[10px]"
+      textSize = "text-[14px]"
       backgroundClass = ""
     } else {
       statusText = data.status
@@ -43,7 +43,7 @@ export default function Ping({ group, service, style }) {
       statusText = t("docker.running")
     } else if (style === "dot") {
       statusText = "◉"
-      textSize += "text-[10px]"
+      textSize = "text-[14px]"
       backgroundClass = ""
     } else {
       statusText = ping

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -23,8 +23,8 @@ export default function Ping({ group, service, style }) {
     );
   }
 
-  var statusText = `HTTP status ${data.status}`;
-  var status;
+  let statusText = `HTTP status ${data.status}`;
+  let status;
 
   if (data.status > 403) {
     if (style === "basic") {
@@ -43,7 +43,7 @@ export default function Ping({ group, service, style }) {
   }
 
   // Sucessful ping
-  var ping = t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })
+  const ping = t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })
 
   statusText += ` (${ping})`;
 

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import useSWR from "swr";
 
-export default function Ping({ group, service }) {
+export default function Ping({ group, service, style }) {
   const { t } = useTranslation();
   const { data, error } = useSWR(`/api/ping?${new URLSearchParams({ group, service }).toString()}`, {
     refreshInterval: 30000
@@ -23,20 +23,41 @@ export default function Ping({ group, service }) {
     );
   }
 
-  const statusText = `${service}: HTTP status ${data.status}`;
-  
+  var statusText = `HTTP status ${data.status}`;
+  var status;
+
   if (data.status > 403) {
+    if (style === "basic") {
+      status = t("docker.offline")
+    } else if (style === "dot") {
+      status = "◉"
+    } else {
+      status = data.status
+    }
+
     return (
       <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden ping-status-invalid" title={statusText}>
-        <div className="text-[8px] font-bold text-rose-500/80">{data.status}</div>
+        <div className="text-[8px] font-bold text-rose-500/80 uppercase">{status}</div>
       </div>
     );
   }
-  
+
+  // Sucessful ping
+  var ping = t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })
+
+  statusText += ` (${ping})`;
+
+  if (style === "basic") {
+    status = t("docker.running")
+  } else if (style === "dot") {
+    status = "◉"
+  } else {
+    status = ping
+  }
+
   return (
     <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden ping-status-valid" title={statusText}>
-      <div className="text-[8px] font-bold text-emerald-500/80">{t("common.ms", { value: data.latency, style: "unit", unit: "millisecond", maximumFractionDigits: 0 })}</div>
+      <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{status}</div>
     </div>
   );
-
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well as a PR to the docs for the new widget.
-->

Adds ping indicator styles "dot" and "basic":
![Bildschirmfoto 2023-09-27 um 13 33 13](https://github.com/benphelps/homepage/assets/5812715/e216da3e-ccdd-4184-8afb-c0b98daf8200)
![image](https://github.com/benphelps/homepage/assets/5812715/530ce500-b6d7-4172-bb1e-b75437b11477)

Closes: https://github.com/benphelps/homepage/discussions/1289

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [X] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
