### PR TITLE
Added choice for first day in a week with a fix

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -358,6 +358,7 @@ export function cleanServiceGroups(groups) {
           mappings, // customapi widget
           refreshInterval,
           integrations, // calendar widget
+          firstDayInWeek,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -443,6 +444,7 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "calendar") {
           if (integrations) cleanedService.widget.integrations = integrations;
+          if (firstDayInWeek) cleanedService.widget.firstDayInWeek = firstDayInWeek;
         }
       }
 

--- a/src/widgets/calendar/monthly-view.jsx
+++ b/src/widgets/calendar/monthly-view.jsx
@@ -98,13 +98,13 @@ export default function MonthlyView({ service }) {
 
   const dayNames = Info.weekdays("short", { locale: i18n.language });
 
-  const firstDayInCalendar = widget?.firstDayInCalendar ? widget?.firstDayInCalendar?.toLowerCase() : "monday";
-  for (let i = 1; i < dayInWeekId[firstDayInCalendar]; i+=1) {
+  const firstDayInWeekCalendar = widget?.firstDayInWeek ? widget?.firstDayInWeek?.toLowerCase() : "monday";
+  for (let i = 1; i < dayInWeekId[firstDayInWeekCalendar]; i+=1) {
     dayNames.push(dayNames.shift());
   }
 
-  const daysInWeek = useMemo(() => [ ...Array(7).keys() ].map( i => i + dayInWeekId[firstDayInCalendar]
-  ), [(firstDayInCalendar)]);
+  const daysInWeek = useMemo(() => [ ...Array(7).keys() ].map( i => i + dayInWeekId[firstDayInWeekCalendar]
+  ), [firstDayInWeekCalendar]);
 
   if (!showDate) {
     return <div className="w-full text-center" />;
@@ -112,8 +112,9 @@ export default function MonthlyView({ service }) {
 
   const firstWeek = DateTime.local(showDate.year, showDate.month, 1).setLocale(i18n.language);
 
+  const weekIncrementChange = dayInWeekId[firstDayInWeekCalendar] > firstWeek.weekday ? -1 : 0;
   let weekNumbers = [ ...Array(Math.ceil(5) + 1).keys() ]
-    .map(i => firstWeek.weekNumber+i);
+    .map(i => firstWeek.weekNumber + weekIncrementChange + i);
 
   if (weekNumbers.includes(55)) {
     // if we went too far with the weeks, it's the beginning of the year


### PR DESCRIPTION
## Proposed change

Related to calendar widget https://github.com/benphelps/homepage/pull/2077 , adds a configuration for first day of the week.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: https://github.com/benphelps/homepage-docs/pull/163
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
