### PR TITLE
Update services/glances.md with correct info/glances link

### DIFF
--- a/docs/widgets/services/glances.md
+++ b/docs/widgets/services/glances.md
@@ -5,7 +5,7 @@ description: Glances Widget Configuration
 
 <img width="1614" alt="glances" src="https://github.com/benphelps/homepage-docs/assets/82196/25648c97-2c1b-4db0-b5a5-f1509806079c">
 
-_(Find the Glances information widget [here](../services/glances.md))_
+_(Find the Glances information widget [here](../info/glances.md))_
 
 The Glances widget allows you to monitor the resources (cpu, memory, diskio, sensors & processes) of host or another machine. You can have multiple instances by adding another service block.
 


### PR DESCRIPTION
## Proposed change

At https://gethomepage.dev/v0.7.0/widgets/services/glances/ the "Find the Glances information widget [here]" links back to itself instead of the info widget link, fixing that

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (documentation)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding  documentation.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
