### PR TITLE
Enhancement: go to current day when clicking calendar month name

### DIFF
--- a/src/widgets/calendar/monthly-view.jsx
+++ b/src/widgets/calendar/monthly-view.jsx
@@ -126,7 +126,7 @@ export default function MonthlyView({ service }) {
   return <div className="w-full text-center">
     <div className="flex-col">
       <span><button type="button" onClick={ () => setShowDate(showDate.minus({ months: 1 }).startOf("day")) } className={classNames(monthButton)}>&lt;</button></span>
-      <span>{ showDate.setLocale(i18n.language).toFormat("MMMM y") }</span>
+      <span><button type="button" onClick={ () => setShowDate(currentDate.startOf("day")) }>{ showDate.setLocale(i18n.language).toFormat("MMMM y") }</button></span>
       <span><button type="button" onClick={ () => setShowDate(showDate.plus({ months: 1 }).startOf("day")) } className={classNames(monthButton)}>&gt;</button></span>
     </div>
 


### PR DESCRIPTION
## Proposed change

Implements "Today" action for calendar when clicking  the month name

Closes #2089

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding  documentation.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
