### PR TITLE
Documentation: Remove extra Service Widgets in new documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,6 @@ nav:
       - widgets/services/homeassistant.md
       - widgets/services/homebridge.md
       - widgets/services/immich.md
-      - widgets/services/index.md
       - widgets/services/jackett.md
       - widgets/services/jdownloader.md
       - widgets/services/jellyfin.md


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/en/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

There is an extra service widgets between Immich and Jackett?
![20230930182658](https://github.com/benphelps/homepage/assets/23041178/8b2acfd2-7528-4678-9cb4-39f3bd432c8f)



## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
