### PR TITLE
Add more fields to tailscale widget

### DIFF
--- a/docs/widgets/services/tailscale.md
+++ b/docs/widgets/services/tailscale.md
@@ -7,7 +7,7 @@ You will need to generate an API access token from the [keys page](https://login
 
 To find your device ID, go to the [machine overview page](https://login.tailscale.com/admin/machines) and select your machine. In the "Machine Details" section, copy your `ID`. It will end with `CNTRL`.
 
-Allowed fields: `["address", "last_seen", "expires"]`.
+Allowed fields: `["hostname", "address", "name", "last_seen", "expires", "client_version"]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -266,7 +266,9 @@
         "total": "Total"
     },
     "tailscale": {
+        "hostname": "Hostname",
         "address": "Address",
+        "name": "Name",
         "expires": "Expires",
         "never": "Never",
         "last_seen": "Last Seen",
@@ -277,7 +279,8 @@
         "hours": "{{number}}h",
         "minutes": "{{number}}m",
         "seconds": "{{number}}s",
-        "ago": "{{value}} Ago"
+        "ago": "{{value}} Ago",
+        "client_version": "Client Version"
     },
     "tdarr": {
         "queue": "Queue",

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -18,18 +18,24 @@ export default function Component({ service }) {
   if (!statsData) {
     return (
       <Container service={service}>
+        <Block label="tailscale.hostname" />
         <Block label="tailscale.address" />
+        <Block label="tailscale.name" />
         <Block label="tailscale.last_seen" />
         <Block label="tailscale.expires" />
+        <Block label="tailscale.client_version" />
       </Container>
     );
   }
 
   const {
+    hostname,
     addresses: [address],
+    name,
     keyExpiryDisabled,
     lastSeen,
     expires,
+    clientVersion,
   } = statsData;
 
   const now = new Date();
@@ -64,9 +70,12 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
+      <Block label="tailscale.hostname" value={hostname} />
       <Block label="tailscale.address" value={address} />
+      <Block label="tailscale.name" value={name} />
       <Block label="tailscale.last_seen" value={getLastSeen()} />
       <Block label="tailscale.expires" value={getExpiry()} />
+      <Block label="tailscale.client_version" value={clientVersion} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

Include three new fields in the tailscale widget.

- hostname is the machine name in the admin console. 
- name is the MagicDNS name of the device.
- clientVersion is the version of the Tailscale client software.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
