### PR TITLE
Enhancement: statusStyle improvements

### DIFF
--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -123,14 +123,7 @@ Services may have an optional `ping` property that allows you to monitor the ava
 
 <img width="1038" alt="Ping" src="https://github.com/benphelps/homepage/assets/88257202/7bc13bd3-0d0b-44e3-888c-a20e069a3233">
 
-You can also apply different styles to the ping indicator by using the `statusStyle` property. The default is no value, and displays the response time in ms, but you can also use `dot` or `basic`. `dot` shows a green dot for a successful ping, and `basic` shows either ONLINE or OFFLINE to match the status style of Docker containers. For example:
-
-```yaml
-    - Sonarr:
-        ...
-        ping: http://sonarr.host/
-        statusStyle: dot
-```
+You can also apply different styles to the ping indicator by using the `statusStyle` property, see [settings](settings.md#status-style).
 
 ## Docker Integration
 

--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -382,9 +382,9 @@ If you have both set the per-service settings take precedence.
 
 ## Status Style
 
-You can choose from the following styles for status / ping: `dot` or `basic`
+You can choose from the following styles for docker or k8s status and ping: `dot` or `basic`
 
-The default is no value, and displays the ping response time in ms. `dot` shows a green dot for a successful ping, and `basic` shows either ONLINE or OFFLINE to match the status style of Docker containers. For example:
+The default is no value, and displays the ping response time in ms. `dot` shows a green dot for a successful ping or healthy status, and `basic` shows either ONLINE or OFFLINE to match the status style of Docker containers. For example:
 
 ```yaml
     - Sonarr:

--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -380,6 +380,33 @@ or per-service (`services.yaml`) with:
 
 If you have both set the per-service settings take precedence.
 
+## Status Style
+
+You can choose from the following styles for status / ping: `dot` or `basic`
+
+The default is no value, and displays the ping response time in ms. `dot` shows a green dot for a successful ping, and `basic` shows either ONLINE or OFFLINE to match the status style of Docker containers. For example:
+
+```yaml
+    - Sonarr:
+        ...
+        ping: http://sonarr.host/
+        statusStyle: dot
+```
+
+```yaml
+statusStyle: 'dot'
+```
+
+or per-service (`services.yaml`) with:
+
+```yaml
+- Example Service:
+    ...
+    statusStyle: 'dot'
+```
+
+If you have both set, the per-service settings take precedence.
+
 ## Hide Widget Error Messages
 
 Hide the visible API error messages either globally in `settings.yaml`:

--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -384,14 +384,11 @@ If you have both set the per-service settings take precedence.
 
 You can choose from the following styles for docker or k8s status and ping: `dot` or `basic`
 
-The default is no value, and displays the ping response time in ms. `dot` shows a green dot for a successful ping or healthy status, and `basic` shows either ONLINE or OFFLINE to match the status style of Docker containers. For example:
+- The default is no value, and displays the ping response time in ms and the docker / k8s container status
+- `dot` shows a green dot for a successful ping or healthy status.
+- `basic` shows either UP or DOWN for ping
 
-```yaml
-    - Sonarr:
-        ...
-        ping: http://sonarr.host/
-        statusStyle: dot
-```
+For example:
 
 ```yaml
 statusStyle: 'dot'

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -76,9 +76,7 @@
         "unhealthy": "Unhealthy",
         "not_found": "Not Found",
         "exited": "Exited",
-        "partial": "Partial",
-        "up": "Up",
-        "down": "Down"
+        "partial": "Partial"
     },
     "ping": {
         "error": "Error",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -76,11 +76,15 @@
         "unhealthy": "Unhealthy",
         "not_found": "Not Found",
         "exited": "Exited",
-        "partial": "Partial"
+        "partial": "Partial",
+        "up": "Up",
+        "down": "Down"
     },
     "ping": {
         "error": "Error",
-        "ping": "Ping"
+        "ping": "Ping",
+        "down": "Down",
+        "up": "Up"
     },
     "emby": {
         "playing": "Playing",

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -15,6 +15,7 @@ export default function Item({ service, group }) {
   const hasLink = service.href && service.href !== "#";
   const { settings } = useContext(SettingsContext);
   const showStats = (service.showStats === false) ? false : settings.showStats;
+  const statusStyle = (service.statusStyle !== undefined) ? service.statusStyle : settings.statusStyle;
   const [statsOpen, setStatsOpen] = useState(service.showStats);
   const [statsClosing, setStatsClosing] = useState(false);
 
@@ -79,7 +80,7 @@ export default function Item({ service, group }) {
           <div className="absolute top-0 right-0 flex flex-row justify-end gap-2 mr-2 z-30 service-tags">
               {service.ping && (
                 <div className="flex-shrink-0 flex items-center justify-center service-tag service-ping">
-                  <Ping group={group} service={service.name} style={service.statusStyle} />
+                  <Ping group={group} service={service.name} style={statusStyle} />
                   <span className="sr-only">Ping status</span>
                 </div>
               )}

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -77,7 +77,7 @@ export default function Item({ service, group }) {
             </div>
           )}
 
-          <div className="absolute top-0 right-0 flex flex-row justify-end gap-2 mr-2 z-30 service-tags">
+          <div className={`absolute top-0 right-0 flex flex-row justify-end ${statusStyle === 'dot' ? 'gap-0' : 'gap-2'} mr-2 z-30 service-tags`}>
               {service.ping && (
                 <div className="flex-shrink-0 flex items-center justify-center service-tag service-ping">
                   <Ping group={group} service={service.name} style={statusStyle} />
@@ -91,7 +91,7 @@ export default function Item({ service, group }) {
                   onClick={() => (statsOpen ? closeStats() : setStatsOpen(true))}
                   className="flex-shrink-0 flex items-center justify-center cursor-pointer service-tag service-container-stats"
                 >
-                  <Status service={service} />
+                  <Status service={service} style={statusStyle} />
                   <span className="sr-only">View container stats</span>
                 </button>
               )}
@@ -101,7 +101,7 @@ export default function Item({ service, group }) {
                   onClick={() => (statsOpen ? closeStats() : setStatsOpen(true))}
                   className="flex-shrink-0 flex items-center justify-center cursor-pointer service-tag service-app"
                 >
-                  <KubernetesStatus service={service} />
+                  <KubernetesStatus service={service} style={statusStyle} />
                   <span className="sr-only">View container stats</span>
                 </button>
               )}

--- a/src/components/services/kubernetes-status.jsx
+++ b/src/components/services/kubernetes-status.jsx
@@ -30,7 +30,7 @@ export default function KubernetesStatus({ service, style }) {
 
   if (style === 'dot') {
     colorClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '');
-    backgroundClass = "p-3 hover:bg-theme-500/10 dark:hover:bg-theme-900/50";
+    backgroundClass = "p-3 hover:bg-theme-500/10 dark:hover:bg-theme-900/20";
   }
 
   return (

--- a/src/components/services/kubernetes-status.jsx
+++ b/src/components/services/kubernetes-status.jsx
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { t } from "i18next";
 
-export default function KubernetesStatus({ service }) {
+export default function KubernetesStatus({ service, style }) {
   const podSelectorString = service.podSelector !== undefined ? `podSelector=${service.podSelector}` : "";
   const { data, error } = useSWR(`/api/kubernetes/status/${service.namespace}/${service.app}?${podSelectorString}`);
 
@@ -11,16 +11,19 @@ export default function KubernetesStatus({ service }) {
   let colorClass = "text-black/20 dark:text-white/40 ";
 
   if (error) {
-    statusLabel = statusTitle = t("docker.error");
+    statusTitle = t("docker.error");
+    statusLabel = statusTitle;
     colorClass = "text-rose-500/80";
   } else if (data) {
     if (data.status === "running") {
-      statusLabel = statusTitle = data.health ?? data.status;
+      statusTitle = data.health ?? data.status;
+      statusLabel = statusTitle;
       colorClass = "text-emerald-500/80";
     }
   
     if (data.status === "not found" || data.status === "down" || data.status === "partial") {
-      statusLabel = statusTitle = data.status;
+      statusTitle = data.status;
+      statusLabel = statusTitle;
       colorClass = "text-orange-400/50 dark:text-orange-400/80";
     }
   }
@@ -33,7 +36,7 @@ export default function KubernetesStatus({ service }) {
   return (
     <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] k8s-status-${statusLabel.toLowerCase().replace(' ', '')}`} title={statusTitle}>
       {style !== 'dot' && <div className={`text-[8px] font-bold ${colorClass} uppercase`}>{statusLabel}</div>}
-      {style == 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}></div>}
+      {style === 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}/>}
     </div>
   );
 }

--- a/src/components/services/kubernetes-status.jsx
+++ b/src/components/services/kubernetes-status.jsx
@@ -5,31 +5,35 @@ export default function KubernetesStatus({ service }) {
   const podSelectorString = service.podSelector !== undefined ? `podSelector=${service.podSelector}` : "";
   const { data, error } = useSWR(`/api/kubernetes/status/${service.namespace}/${service.app}?${podSelectorString}`);
 
+  let statusLabel = t("docker.unknown");
+  let statusTitle = "";
+  let backgroundClass = "px-1.5 py-0.5 bg-theme-500/10 dark:bg-theme-900/50";
+  let colorClass = "text-black/20 dark:text-white/40 ";
+
   if (error) {
-    <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden k8s-status-error" title={t("docker.error")}>
-      <div className="text-[8px] font-bold text-rose-500/80 uppercase">{t("docker.error")}</div>
-    </div>
+    statusLabel = statusTitle = t("docker.error");
+    colorClass = "text-rose-500/80";
+  } else if (data) {
+    if (data.status === "running") {
+      statusLabel = statusTitle = data.health ?? data.status;
+      colorClass = "text-emerald-500/80";
+    }
+  
+    if (data.status === "not found" || data.status === "down" || data.status === "partial") {
+      statusLabel = statusTitle = data.status;
+      colorClass = "text-orange-400/50 dark:text-orange-400/80";
+    }
   }
 
-  if (data && data.status === "running") {
-    return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden k8s-status" title={data.health ?? data.status}>
-        <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{data.health ?? data.status}</div>
-      </div>
-    );
-  }
-
-  if (data && (data.status === "not found" || data.status === "down" || data.status === "partial")) {
-    return (
-      <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden k8s-status-warning" title={data.status}>
-        <div className="text-[8px] font-bold text-orange-400/50 dark:text-orange-400/80 uppercase">{data.status}</div>
-      </div>
-    );
+  if (style === 'dot') {
+    colorClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '');
+    backgroundClass = "p-3 hover:bg-theme-500/10 dark:hover:bg-theme-900/50";
   }
 
   return (
-    <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden k8s-status-unknown">
-      <div className="text-[8px] font-bold text-black/20 dark:text-white/40 uppercase">{t("docker.unknown")}</div>
+    <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] k8s-status-${statusLabel.toLowerCase().replace(' ', '')}`} title={statusTitle}>
+      {style !== 'dot' && <div className={`text-[8px] font-bold ${colorClass} uppercase`}>{statusLabel}</div>}
+      {style == 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}></div>}
     </div>
   );
 }

--- a/src/components/services/kubernetes-status.jsx
+++ b/src/components/services/kubernetes-status.jsx
@@ -34,7 +34,7 @@ export default function KubernetesStatus({ service, style }) {
   }
 
   return (
-    <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] k8s-status-${statusLabel.toLowerCase().replace(' ', '')}`} title={statusTitle}>
+    <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] k8s-status`} title={statusTitle}>
       {style !== 'dot' && <div className={`text-[8px] font-bold ${colorClass} uppercase`}>{statusLabel}</div>}
       {style === 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}/>}
     </div>

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -25,7 +25,7 @@ export default function Ping({ group, service, style }) {
     statusTitle += ` ${data.status}`
 
     if (style === "basic") {
-      statusText = t("docker.offline")
+      statusText = t("ping.down")
     } else {
       statusText = data.status
     }
@@ -35,7 +35,7 @@ export default function Ping({ group, service, style }) {
     colorClass = "text-emerald-500/80"
 
     if (style === "basic") {
-      statusText = t("docker.running")
+      statusText = t("ping.up")
     } else {
       statusText = ping
     }

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -49,7 +49,7 @@ export default function Ping({ group, service, style }) {
   return (
     <div className={`w-auto text-center rounded-b-[3px] overflow-hidden ping-status ${backgroundClass}`} title={statusTitle}>
       {style !== 'dot' && <div className={`font-bold uppercase text-[8px] ${colorClass}`}>{statusText}</div>}
-      {style == 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}></div>}
+      {style === 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}/>}
     </div>
   );
 }

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -7,7 +7,6 @@ export default function Ping({ group, service, style }) {
     refreshInterval: 30000
   });
 
-  let textSize = "text-[8px]";
   let colorClass = ""
   let backgroundClass = "bg-theme-500/10 dark:bg-theme-900/50";
   let statusTitle = "HTTP status";
@@ -27,10 +26,6 @@ export default function Ping({ group, service, style }) {
 
     if (style === "basic") {
       statusText = t("docker.offline")
-    } else if (style === "dot") {
-      statusText = "◉"
-      textSize = "text-[14px]"
-      backgroundClass = ""
     } else {
       statusText = data.status
     }
@@ -41,18 +36,23 @@ export default function Ping({ group, service, style }) {
 
     if (style === "basic") {
       statusText = t("docker.running")
-    } else if (style === "dot") {
-      statusText = "◉"
-      textSize = "text-[14px]"
-      backgroundClass = ""
     } else {
       statusText = ping
     }
   }
 
+  if (style === "dot") {
+    backgroundClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '')
+  }
+
   return (
-    <div className={`w-auto px-1.5 py-0.5 text-center rounded-b-[3px] overflow-hidden ping-status-invalid ${backgroundClass}`} title={statusTitle}>
-      <div className={`font-bold uppercase ${textSize} ${colorClass}`}>{statusText}</div>
-    </div>
+    <>
+    {style !== 'dot' &&
+      <div className={`w-auto px-1.5 py-0.5 text-center rounded-b-[3px] overflow-hidden ping-status-invalid ${style !== 'dot' ? backgroundClass : ''}`} title={statusTitle}>
+       <div className={`font-bold uppercase text-[8px] ${colorClass}`}>{statusText}</div>
+      </div>
+    }
+    {style == 'dot' && <div className={`rounded-full h-[9px] w-[9px] ${backgroundClass}`} title={statusTitle}></div>}
+    </>
   );
 }

--- a/src/components/services/ping.jsx
+++ b/src/components/services/ping.jsx
@@ -8,7 +8,7 @@ export default function Ping({ group, service, style }) {
   });
 
   let colorClass = ""
-  let backgroundClass = "bg-theme-500/10 dark:bg-theme-900/50";
+  let backgroundClass = "bg-theme-500/10 dark:bg-theme-900/50 px-1.5 py-0.5";
   let statusTitle = "HTTP status";
   let statusText;
 
@@ -42,17 +42,14 @@ export default function Ping({ group, service, style }) {
   }
 
   if (style === "dot") {
-    backgroundClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '')
+    backgroundClass = 'p-3';
+    colorClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '');
   }
 
   return (
-    <>
-    {style !== 'dot' &&
-      <div className={`w-auto px-1.5 py-0.5 text-center rounded-b-[3px] overflow-hidden ping-status-invalid ${style !== 'dot' ? backgroundClass : ''}`} title={statusTitle}>
-       <div className={`font-bold uppercase text-[8px] ${colorClass}`}>{statusText}</div>
-      </div>
-    }
-    {style == 'dot' && <div className={`rounded-full h-[9px] w-[9px] ${backgroundClass}`} title={statusTitle}></div>}
-    </>
+    <div className={`w-auto text-center rounded-b-[3px] overflow-hidden ping-status ${backgroundClass}`} title={statusTitle}>
+      {style !== 'dot' && <div className={`font-bold uppercase text-[8px] ${colorClass}`}>{statusText}</div>}
+      {style == 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}></div>}
+    </div>
   );
 }

--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -52,7 +52,7 @@ export default function Status({ service, style }) {
   return (
     <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] docker-status-${statusLabel.toLowerCase().replace(' ', '')}`} title={statusTitle}>
       {style !== 'dot' && <div className={`text-[8px] font-bold ${colorClass} uppercase`}>{statusLabel}</div>}
-      {style == 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}></div>}
+      {style === 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}/>}
     </div>
   );
 }

--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -46,7 +46,7 @@ export default function Status({ service, style }) {
 
   if (style === 'dot') {
     colorClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '');
-    backgroundClass = "p-3 hover:bg-theme-500/10 dark:hover:bg-theme-900/50";
+    backgroundClass = "p-3 hover:bg-theme-500/10 dark:hover:bg-theme-900/20";
   }
 
   return (

--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -1,65 +1,58 @@
 import { useTranslation } from "react-i18next";
 import useSWR from "swr";
 
-export default function Status({ service }) {
+export default function Status({ service, style }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/docker/status/${service.container}/${service.server || ""}`);
 
+  let statusLabel = t("docker.unknown");
+  let statusTitle = "";
+  let backgroundClass = "px-1.5 py-0.5 bg-theme-500/10 dark:bg-theme-900/50";
+  let colorClass = "text-black/20 dark:text-white/40 ";
+
   if (error) {
-    <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden docker-error" title={t("docker.error")}>
-      <div className="text-[8px] font-bold text-rose-500/80 uppercase">{t("docker.error")}</div>
-    </div>
-  }
-
-  if (data) {
-    let statusLabel = "";
-
+    statusTitle = t("docker.error");
+    colorClass = "text-rose-500/80";
+  } else if (data) {
     if (data.status?.includes("running")) {
       if (data.health === "starting") {
-        return (
-          <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden docker-starting" title={t("docker.starting")}>
-            <div className="text-[8px] font-bold text-blue-500/80 uppercase">{t("docker.starting")}</div>
-          </div>
-        );
+          statusTitle = t("docker.starting");
+          colorClass = "text-blue-500/80";
       }
 
       if (data.health === "unhealthy") {
-        return (
-          <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden docker-unhealthy" title={t("docker.unhealthy")}>
-            <div className="text-[8px] font-bold text-orange-400/50 dark:text-orange-400/80 uppercase">{t("docker.unhealthy")}</div>
-          </div>
-        );
+          statusTitle = t("docker.unhealthy");
+          colorClass = "text-orange-400/50 dark:text-orange-400/80";
       }
 
       if (!data.health) {
-        statusLabel = data.status.replace("running", t("docker.running"))
+        statusLabel = data.status.replace("running", t("docker.running"));
       } else {
-        statusLabel = data.health === "healthy" ? t("docker.healthy") : data.health
+        statusLabel = data.health === "healthy" ? t("docker.healthy") : data.health;
       }
 
-      return (
-        <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden docker-status" title={statusLabel}>
-          <div className="text-[8px] font-bold text-emerald-500/80 uppercase">{statusLabel}</div>
-        </div>
-      );
+      statusTitle = statusLabel;
+      colorClass = "text-emerald-500/80";
     }
     
     if (data.status === "not found" || data.status === "exited" || data.status?.startsWith("partial")) {
       if (data.status === "not found") statusLabel = t("docker.not_found")
       else if (data.status === "exited") statusLabel = t("docker.exited")
       else statusLabel = data.status.replace("partial", t("docker.partial"))
-      return (
-        <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden docker-status-warning" title={statusLabel}>
-          <div className="text-[8px] font-bold text-orange-400/50 dark:text-orange-400/80 uppercase">{statusLabel}</div>
-        </div>
-      );
+      colorClass = "text-orange-400/50 dark:text-orange-400/80";
     }
   }
 
+  if (style === 'dot') {
+    colorClass = colorClass.replace('text-', 'bg-').replace(/\/\d\d$/, '');
+    backgroundClass = "p-3 hover:bg-theme-500/10 dark:hover:bg-theme-900/50";
+  }
+
   return (
-    <div className="w-auto px-1.5 py-0.5 text-center bg-theme-500/10 dark:bg-theme-900/50 rounded-b-[3px] overflow-hidden docker-status-unknown">
-      <div className="text-[8px] font-bold text-black/20 dark:text-white/40 uppercase">{t("docker.unknown")}</div>
+    <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] docker-status-${statusLabel.toLowerCase().replace(' ', '')}`} title={statusTitle}>
+      {style !== 'dot' && <div className={`text-[8px] font-bold ${colorClass} uppercase`}>{statusLabel}</div>}
+      {style == 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}></div>}
     </div>
   );
 }

--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -50,7 +50,7 @@ export default function Status({ service, style }) {
   }
 
   return (
-    <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] docker-status-${statusLabel.toLowerCase().replace(' ', '')}`} title={statusTitle}>
+    <div className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] docker-status`} title={statusTitle}>
       {style !== 'dot' && <div className={`text-[8px] font-bold ${colorClass} uppercase`}>{statusLabel}</div>}
       {style === 'dot' && <div className={`rounded-full h-3 w-3 ${colorClass}`}/>}
     </div>

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -259,6 +259,9 @@ export async function servicesFromKubernetes() {
         if (ingress.metadata.annotations[`${ANNOTATION_BASE}/ping`]) {
           constructedService.ping = ingress.metadata.annotations[`${ANNOTATION_BASE}/ping`];
         }
+        if (ingress.metadata.annotations[`${ANNOTATION_BASE}/statusStyle`]) {
+          constructedService.statusStyle = ingress.metadata.annotations[`${ANNOTATION_BASE}/statusStyle`];
+        }
         Object.keys(ingress.metadata.annotations).forEach((annotation) => {
           if (annotation.startsWith(ANNOTATION_WIDGET_BASE)) {
             shvl.set(


### PR DESCRIPTION
## Proposed change

This finishes the job properly from #2074 

- style can be set in settings
- Ping & docker / k8s status use the same dot
- support k8s with the styles
- changes to use a rounded div with height, not ◉
- Changes ping to be up / down, cause its ping

<img width="67" alt="Screenshot 2023-10-04 at 9 08 50 PM" src="https://github.com/benphelps/homepage/assets/4887959/b611d357-ccfe-4a78-8ba7-dde36163159a">

_Will squash_

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
